### PR TITLE
Handle libcurl calling the read_callback after we pause it

### DIFF
--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -61,8 +61,8 @@ function read_callback(
     try
         req = unsafe_pointer_to_objref(req_p)::gRPCRequest
 
-        # Check for race condition
-        @assert !req.curl_done_reading.set
+        # Sometimes curl calls again even after we tell it to pause
+        req.curl_done_reading.set && return CURL_READFUNC_PAUSE
 
         buf_p = pointer(req.request.data) + req.request_ptr
         n_left = req.request.size - req.request_ptr


### PR DESCRIPTION
Sometimes during the request streaming benchmark we would hang with an assert:

```
┌ Error: read_callback: unexpected error
│   err = AssertionError: !(req.curl_done_reading.set)
└ @ gRPCClient ~/Git/gRPCClient.jl/src/Curl.jl:98
```

It looks like curl still calls the `read_callback` even after we paused it sometimes. Instead of asserting this, just tell it to pause again.