### PR TITLE
Reworking benchmarking with a new sub package gRPCClientUtils.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ The documentation for gRPCClient.jl can be found [here](https://juliaio.github.i
 
 ## Benchmarks
 
-**TODO: PrettyTables.jl Benchmark Results Here**
+```
+╭──────────────────────────────────┬─────────┬────────┬─────────────┬──────────┬────────────┬──────────────┬─────────┬──────┬──────╮
+│                        Benchmark │       N │ Memory │ Allocations │ Duration │ Throughput │ Avg duration │ Std-dev │  Min │  Max │
+│                                  │   calls │    MiB │             │        s │    calls/s │           μs │      μs │   μs │   μs │
+├──────────────────────────────────┼─────────┼────────┼─────────────┼──────────┼────────────┼──────────────┼─────────┼──────┼──────┤
+│                    workload_smol │   94000 │   3.74 │       85110 │     5.01 │      18756 │           53 │     4.2 │   47 │   71 │
+│        workload_32_224_224_uint8 │    2800 │  63.78 │        9230 │     5.11 │        548 │         1826 │   378.6 │ 1598 │ 2657 │
+│       workload_streaming_request │ 2566000 │   0.61 │        6615 │     4.99 │     514001 │            2 │    0.61 │    1 │   16 │
+│      workload_streaming_response │  985000 │   13.0 │       27721 │      5.0 │     197101 │            5 │    0.48 │    4 │    7 │
+│ workload_streaming_bidirectional │ 2568000 │   1.98 │       25503 │     4.99 │     514539 │            2 │     0.5 │    1 │   12 │
+╰──────────────────────────────────┴─────────┴────────┴─────────────┴──────────┴────────────┴──────────────┴─────────┴──────┴──────╯
+```
 
 ## Acknowledgement
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -90,15 +90,43 @@ grpc_async_await(client::gRPCServiceClient{TRequest,true,TResponse,false},reques
 gRPCServiceCallException
 ```
 
-## Benchmarking
+## gRPCClientUtils.jl
 
-All benchmark tests run against the Test gRPC Server in `test/go`. See the relevant [documentation](#Test-gRPC-Server) for information on how to run this.
+A module for benchmarking and stress testing has been included in `utils/gRPCClientUtils.jl`. In order to add it to your test environment:
 
-**TODO: information on how to run the benchmarks with PrettyTables.jl support**
+```julia
+using Pkg
+Pkg.add(path="utils/gRPCClientUtils.jl")
+```
+
+### Benchmarks
+
+All benchmarks run against the Test gRPC Server in `test/go`. See the relevant [documentation](#Test-gRPC-Server) for information on how to run this.
+
+#### All Benchmarks w/ PrettyTables.jl
+
+```julia
+using gRPCClientUtils
+
+benchmark_table()
+```
+
+```
+╭──────────────────────────────────┬─────────┬────────┬─────────────┬──────────┬────────────┬──────────────┬─────────┬──────┬──────╮
+│                        Benchmark │       N │ Memory │ Allocations │ Duration │ Throughput │ Avg duration │ Std-dev │  Min │  Max │
+│                                  │   calls │    MiB │             │        s │    calls/s │           μs │      μs │   μs │   μs │
+├──────────────────────────────────┼─────────┼────────┼─────────────┼──────────┼────────────┼──────────────┼─────────┼──────┼──────┤
+│                    workload_smol │   94000 │   3.74 │       85110 │     5.01 │      18756 │           53 │     4.2 │   47 │   71 │
+│        workload_32_224_224_uint8 │    2800 │  63.78 │        9230 │     5.11 │        548 │         1826 │   378.6 │ 1598 │ 2657 │
+│       workload_streaming_request │ 2566000 │   0.61 │        6615 │     4.99 │     514001 │            2 │    0.61 │    1 │   16 │
+│      workload_streaming_response │  985000 │   13.0 │       27721 │      5.0 │     197101 │            5 │    0.48 │    4 │    7 │
+│ workload_streaming_bidirectional │ 2568000 │   1.98 │       25503 │     4.99 │     514539 │            2 │     0.5 │    1 │   12 │
+╰──────────────────────────────────┴─────────┴────────┴─────────────┴──────────┴────────────┴──────────────┴─────────┴──────┴──────╯
+```
 
 ### Stress Workloads
 
-In addition to benchmarks, a number of workloads based on these are available in `workloads.jl`:
+In addition to benchmarks, a number of workloads based on these are available:
 
 - `stress_workload_smol()`
 - `stress_workload_32_224_224_uint8()`

--- a/utils/gRPCClientUtils.jl/Project.toml
+++ b/utils/gRPCClientUtils.jl/Project.toml
@@ -1,0 +1,19 @@
+name = "gRPCClientUtils"
+uuid = "666ced56-cc98-4ae2-88e9-75ed60a27e25"
+version = "0.1.0"
+authors = ["Carroll Vance <cs.vance@icloud.com>"]
+
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+gRPCClient = "aaca4a50-36af-4a1d-b878-4c443f2061ad"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
+ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
+
+[compat]
+BenchmarkTools = "~1.6.0"
+gRPCClient = "~1.0.0"
+PrettyTables = "~3.1.0"
+ProgressBars = "~1.5.0"
+ProtoBuf = "~1.2"
+

--- a/utils/gRPCClientUtils.jl/src/Benchmark.jl
+++ b/utils/gRPCClientUtils.jl/src/Benchmark.jl
@@ -1,0 +1,47 @@
+benchmark_workload_smol() = @benchmark workload_smol(1_000)
+benchmark_workload_32_224_224_uint8() = @benchmark workload_32_224_224_uint8(100)
+benchmark_workload_streaming_request() = @benchmark workload_streaming_request(1_000)
+benchmark_workload_streaming_response() = @benchmark workload_streaming_response(1_000)
+benchmark_workload_streaming_bidirectional() = @benchmark workload_streaming_bidirectional(1_000)
+
+
+function perform_benchmark(f, N)
+    b = @benchmark $f($N)
+    timing = sum(b.times) / 1e9
+    timings_us = b.times ./ 1e3
+    N_sample = length(b.times) * N
+    mem = round(b.memory / (1024*1024), digits=2)
+
+    return [f, N_sample, mem, b.allocs, 
+        round(timing, digits=2), 
+        round(Int, N_sample/timing), # Throughput
+        round(Int, mean(timings_us) / N), # Avg duration
+        round(std(timings_us) / N, digits=2), 
+        round(Int, minimum(timings_us) / N), 
+        round(Int, maximum(timings_us) / N)]
+end
+
+function benchmark_table()
+    grpc_init()
+
+    column_labels = [
+        ["Benchmark", "N", "Memory", "Allocations", "Duration", "Throughput", "Avg duration",  "Std-dev", "Min", "Max"],
+        ["",          "calls", "MiB", "",           "s",        "calls/s",    "μs",            "μs",      "μs",  "μs"]
+    ]
+    all_benchmarks = [
+        (workload_smol, 1_000),
+        (workload_32_224_224_uint8, 100),
+        (workload_streaming_request, 1_000),
+        (workload_streaming_response, 1_000),
+        (workload_streaming_bidirectional, 1_000),
+    ]
+
+    all_results = [perform_benchmark(f, N) for (f, N) in ProgressBar(all_benchmarks)]
+    
+    pretty_table(
+        permutedims(reduce(hcat, all_results));
+        column_labels = column_labels,
+        style         = TextTableStyle(first_line_column_label = crayon"yellow bold"),
+        table_format  = TextTableFormat(borders = text_table_borders__unicode_rounded)
+    )
+end

--- a/utils/gRPCClientUtils.jl/src/Stress.jl
+++ b/utils/gRPCClientUtils.jl/src/Stress.jl
@@ -1,0 +1,11 @@
+function stress_workload(f::Function, n)
+    while true
+        f(n)
+    end
+end
+
+stress_workload_smol() = stress_workload(workload_smol, 1_000)
+stress_workload_32_224_224_uint8() = stress_workload(workload_32_224_224_uint8, 100)
+stress_workload_streaming_request() = stress_workload(workload_streaming_request, 1_000)
+stress_workload_streaming_response() = stress_workload(workload_streaming_response, 1_000)
+stress_workload_streaming_bidirectional() = stress_workload(workload_streaming_bidirectional, 1_000)

--- a/utils/gRPCClientUtils.jl/src/Workloads.jl
+++ b/utils/gRPCClientUtils.jl/src/Workloads.jl
@@ -1,10 +1,3 @@
-using gRPCClient
-using BenchmarkTools
-
-grpc_init()
-
-include("test/gen/test/test_pb.jl")
-
 function workload_32_224_224_uint8(n)
     client = TestService_TestRPC_Client("localhost", 8001)
 
@@ -99,25 +92,3 @@ function workload_streaming_bidirectional(n)
         nothing
     end    
 end
-
-
-function stress_workload(f::Function, n)
-    while true
-        f(n)
-    end
-end
-
-stress_workload_smol() = stress_workload(workload_smol, 1_000)
-stress_workload_32_224_224_uint8() = stress_workload(workload_32_224_224_uint8, 100)
-stress_workload_streaming_request() = stress_workload(workload_streaming_request, 1_000)
-stress_workload_streaming_response() = stress_workload(workload_streaming_response, 1_000)
-stress_workload_streaming_bidirectional() = stress_workload(workload_streaming_bidirectional, 1_000)
-
-benchmark_workload_smol() = @benchmark workload_smol(1_000)
-benchmark_workload_32_224_224_uint8() = @benchmark workload_32_224_224_uint8(100)
-benchmark_workload_streaming_request() = @benchmark workload_streaming_request(1_000)
-benchmark_workload_streaming_response() = @benchmark workload_streaming_response(1_000)
-benchmark_workload_streaming_bidirectional() = @benchmark workload_streaming_bidirectional(1_000)
-
-
-nothing

--- a/utils/gRPCClientUtils.jl/src/gRPCClientUtils.jl
+++ b/utils/gRPCClientUtils.jl/src/gRPCClientUtils.jl
@@ -1,0 +1,29 @@
+module gRPCClientUtils
+
+using gRPCClient
+using BenchmarkTools
+using PrettyTables
+using ProgressBars
+using ProtoBuf
+
+include("../../../test/gen/test/test_pb.jl")
+include("Workloads.jl")
+include("Benchmark.jl")
+include("Stress.jl")
+
+export benchmark_table
+
+export workload_smol
+export workload_32_224_224_uint8
+export workload_streaming_request
+export workload_streaming_response
+export workload_streaming_bidirectional
+
+export stress_workload_smol
+export stress_workload_32_224_224_uint8
+export stress_workload_streaming_request
+export stress_workload_streaming_response
+export stress_workload_streaming_bidirectional
+
+
+end # module gRPCClientUtils


### PR DESCRIPTION
New function benchmark_table uses PrettyTables.jl to optimally display all benchmark results together.

@atthom I worked your benchmark changes into a subpackage called `gRPCClientUtils.jl` and credited you. 