### PR TITLE
Launch go server within runtests.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,10 @@ jobs:
     - name: Build Go gRPC Test Server
       run: go build -o grpc_test_server .
       working-directory: test/go
-    - name: Run Go gRPC Test Server
-      run: ./grpc_test_server &
+    - name: Rename Go executable for windows
+      if: matrix.os == 'windows-latest'
+      run: mv grpc_test_server grpc_test_server.exe
+      shell: pwsh
       working-directory: test/go
     - uses: julia-actions/setup-julia@v1
       with:
@@ -67,8 +69,8 @@ jobs:
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-runtest@v1
       timeout-minutes: 5
-    - name: Stop Go gRPC Test Server
-      run: killall grpc_test_server
+      env: 
+        JULIA_GRPCCLIENT_TEST_START_SERVER: "go"
     - uses: julia-actions/julia-processcoverage@v1
     - uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
This PR runs the test server from within Julia. This solves the issue that background tasks cannot be started in other CI steps on windows. Using the environment variable that tells runtests.jl to start the server also works well for local development. 

Solves https://github.com/JuliaIO/gRPCClient.jl/issues/69

As a bonus, the tight deadline test is marked as broken for windows. It sometimes passes, but I also saw cases where it would not pass even if the deadline was set to a full second. 