### PR TITLE
Fixing precompile timeout handling

### DIFF
--- a/src/gRPCClient.jl
+++ b/src/gRPCClient.jl
@@ -191,9 +191,9 @@ export gRPCServiceCallException
                 grpc_async_await(req)
             end
         catch ex
-            !isa(ex, gRPCServiceCallException) &&
-                ex.code == DEADLINE_EXCEEDED &&
+            if !(isa(ex, gRPCServiceCallException) && ex.grpc_status == GRPC_DEADLINE_EXCEEDED)
                 rethrow(ex)
+            end
 
             @warn """
             DEADLINE_EXCEEDED during gRPCClient.jl precompile


### PR DESCRIPTION
This fixes precompile timeout handling, the exception is now properly checked and an informative message shown.

Fixes https://github.com/JuliaIO/gRPCClient.jl/issues/81