### PR TITLE
Add support for bearer token authentication

### DIFF
--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -238,6 +238,7 @@ mutable struct gRPCRequest
         keepalive = 60,
         max_send_message_length = 4 * 1024 * 1024,
         max_recieve_message_length = 4 * 1024 * 1024,
+        token = nothing,
     )
         !grpc.running && throw(
             gRPCServiceCallException(
@@ -284,6 +285,9 @@ mutable struct gRPCRequest
         headers = curl_slist_append(headers, "te: trailers")
         headers =
             curl_slist_append(headers, "grpc-timeout: $(grpc_timeout_header_val(deadline))")
+        if !isnothing(token)
+            headers = curl_slist_append(headers, "authorization: Bearer $(token)")
+        end
         curl_easy_setopt(easy_handle, CURLOPT_HTTPHEADER, headers)
 
         curl_easy_setopt(easy_handle, CURLOPT_TCP_KEEPALIVE, Clong(1))

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -30,6 +30,8 @@ function service_cb(io, t::CodeGenerators.ServiceType, ctx::CodeGenerators.Conte
         println(io, "\tkeepalive=60,")
         println(io, "\tmax_send_message_length = 4*1024*1024,")
         println(io, "\tmax_recieve_message_length = 4*1024*1024,")
+        # Optional bearer token sent as an `authorization: Bearer <token>` header.
+        println(io, "\ttoken=nothing,")
         println(
             io,
             ") = gRPCClient.gRPCServiceClient{TRequest, $(rpc.request_stream), TResponse, $(rpc.response_stream)}(",
@@ -41,6 +43,7 @@ function service_cb(io, t::CodeGenerators.ServiceType, ctx::CodeGenerators.Conte
         println(io, "\tkeepalive=keepalive,")
         println(io, "\tmax_send_message_length=max_send_message_length,")
         println(io, "\tmax_recieve_message_length=max_recieve_message_length,")
+        println(io, "\ttoken=token,")
         println(io, ")")
 
         # TODO: define a standard way to check whether we should export that is used in both ProtoBuf.jl and gRPCClient.jl

--- a/src/Streaming.jl
+++ b/src/Streaming.jl
@@ -156,6 +156,7 @@ function grpc_async_request(
         keepalive = keepalive,
         max_send_message_length = max_send_message_length,
         max_recieve_message_length = max_recieve_message_length,
+        token = client.token,
     )
 
     request_task = _spawn(() -> grpc_async_stream_request(req, request), client)
@@ -220,6 +221,7 @@ function grpc_async_request(
         keepalive = keepalive,
         max_send_message_length = max_send_message_length,
         max_recieve_message_length = max_recieve_message_length,
+        token = client.token,
     )
 
     response_task = _spawn(() -> grpc_async_stream_response(req, response), client)
@@ -284,6 +286,7 @@ function grpc_async_request(
         keepalive = keepalive,
         max_send_message_length = max_send_message_length,
         max_recieve_message_length = max_recieve_message_length,
+        token = client.token,
     )
 
     request_task = _spawn(() -> grpc_async_stream_request(req, request), client)

--- a/src/Unary.jl
+++ b/src/Unary.jl
@@ -55,6 +55,7 @@ function grpc_async_request(
         keepalive = keepalive,
         max_send_message_length = max_send_message_length,
         max_recieve_message_length = max_recieve_message_length,
+        token = client.token,
     )
 
     req
@@ -127,6 +128,7 @@ function grpc_async_request(
         keepalive = keepalive,
         max_send_message_length = max_send_message_length,
         max_recieve_message_length = max_recieve_message_length,
+        token = client.token,
     )
 
     _spawn(client) do

--- a/src/gRPC.jl
+++ b/src/gRPC.jl
@@ -50,6 +50,9 @@ struct gRPCServiceClient{TRequest,SRequest,TResponse,SResponse}
     keepalive::Float64
     max_send_message_length::Int64
     max_recieve_message_length::Int64
+    # Optional bearer token attached to every request as an
+    # `authorization: Bearer <token>` header. `nothing` sends no header.
+    token::Union{Nothing,String}
 
     function gRPCServiceClient{TRequest,SRequest,TResponse,SResponse}(
         host,
@@ -61,6 +64,7 @@ struct gRPCServiceClient{TRequest,SRequest,TResponse,SResponse}
         keepalive = 60,
         max_send_message_length = 4 * 1024 * 1024,
         max_recieve_message_length = 4 * 1024 * 1024,
+        token = nothing,
     ) where {TRequest<:Any,SRequest,TResponse<:Any,SResponse}
         new(
             grpc,
@@ -72,6 +76,7 @@ struct gRPCServiceClient{TRequest,SRequest,TResponse,SResponse}
             keepalive,
             max_send_message_length,
             max_recieve_message_length,
+            token,
         )
     end
 

--- a/test/gen/test/test_pb.jl
+++ b/test/gen/test/test_pb.jl
@@ -99,6 +99,7 @@ TestService_TestRPC_Client(
     keepalive = 60,
     max_send_message_length = 4*1024*1024,
     max_recieve_message_length = 4*1024*1024,
+    token = nothing,
 ) = gRPCClient.gRPCServiceClient{TRequest,false,TResponse,false}(
     host,
     port,
@@ -109,6 +110,7 @@ TestService_TestRPC_Client(
     keepalive = keepalive,
     max_send_message_length = max_send_message_length,
     max_recieve_message_length = max_recieve_message_length,
+    token = token,
 )
 export TestService_TestRPC_Client
 
@@ -123,6 +125,7 @@ TestService_TestServerStreamRPC_Client(
     keepalive = 60,
     max_send_message_length = 4*1024*1024,
     max_recieve_message_length = 4*1024*1024,
+    token = nothing,
 ) = gRPCClient.gRPCServiceClient{TRequest,false,TResponse,true}(
     host,
     port,
@@ -133,6 +136,7 @@ TestService_TestServerStreamRPC_Client(
     keepalive = keepalive,
     max_send_message_length = max_send_message_length,
     max_recieve_message_length = max_recieve_message_length,
+    token = token,
 )
 export TestService_TestServerStreamRPC_Client
 
@@ -147,6 +151,7 @@ TestService_TestClientStreamRPC_Client(
     keepalive = 60,
     max_send_message_length = 4*1024*1024,
     max_recieve_message_length = 4*1024*1024,
+    token = nothing,
 ) = gRPCClient.gRPCServiceClient{TRequest,true,TResponse,false}(
     host,
     port,
@@ -157,6 +162,7 @@ TestService_TestClientStreamRPC_Client(
     keepalive = keepalive,
     max_send_message_length = max_send_message_length,
     max_recieve_message_length = max_recieve_message_length,
+    token = token,
 )
 export TestService_TestClientStreamRPC_Client
 
@@ -171,6 +177,7 @@ TestService_TestBidirectionalStreamRPC_Client(
     keepalive = 60,
     max_send_message_length = 4*1024*1024,
     max_recieve_message_length = 4*1024*1024,
+    token = nothing,
 ) = gRPCClient.gRPCServiceClient{TRequest,true,TResponse,true}(
     host,
     port,
@@ -181,6 +188,7 @@ TestService_TestBidirectionalStreamRPC_Client(
     keepalive = keepalive,
     max_send_message_length = max_send_message_length,
     max_recieve_message_length = max_recieve_message_length,
+    token = token,
 )
 export TestService_TestBidirectionalStreamRPC_Client
 # gRPCClient.jl END

--- a/test/go/server.go
+++ b/test/go/server.go
@@ -11,7 +11,37 @@ import (
 	"strconv"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
+
+// expectedBearerToken is the token the Julia bearer-auth test sends. Used by
+// the auth interceptor: a request carrying an `authorization` header must
+// present exactly `Bearer <expectedBearerToken>`. Requests without an
+// `authorization` header are left untouched so the rest of the suite (which
+// uses no token) is unaffected.
+const expectedBearerToken = "test-secret-token"
+
+// authInterceptor rejects any request that carries an `authorization` header
+// not equal to the expected bearer token. Absence of the header is allowed so
+// only the dedicated bearer-auth test exercises this path.
+func authInterceptor(
+	ctx context.Context,
+	req any,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if auth := md.Get("authorization"); len(auth) > 0 {
+			if auth[0] != "Bearer "+expectedBearerToken {
+				return nil, status.Error(codes.Unauthenticated, "invalid bearer token")
+			}
+		}
+	}
+	return handler(ctx, req)
+}
 
 type testServiceServer struct {
 	UnimplementedTestServiceServer
@@ -156,7 +186,7 @@ func main() {
 		log.Fatalf("Failed to listen: %v", err)
 	}
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(authInterceptor))
 	RegisterTestServiceServer(grpcServer, newServer(*publicMode))
 
 	log.Printf("gRPC server started")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,12 @@ using gRPCClient
 using Base.Threads
 
 # Import the timeout header formatting function for testing
-import gRPCClient: grpc_timeout_header_val, GRPC_DEADLINE_EXCEEDED
+import gRPCClient: grpc_timeout_header_val, GRPC_DEADLINE_EXCEEDED, GRPC_UNAUTHENTICATED
+
+# The bearer token the test Go server accepts (mirrors expectedBearerToken in
+# test/go/server.go). A request carrying an `authorization` header must present
+# exactly this value; requests without one are unaffected.
+const _TEST_BEARER_TOKEN = "test-secret-token"
 
 # This is primarily used for starting the server when running CI.
 # By launching the server asynchronously within julia, we ensure
@@ -90,6 +95,10 @@ include("gen/test/test_pb.jl")
             # so the construction uses the type-parameter names (raw-buffer support).
             @test contains(generated, "TRequest=TestRequest,")
             @test contains(generated, "TResponse=TestResponse,")
+            # Bearer token kwarg is generated (defaults to nothing) and threaded
+            # through to the underlying gRPCServiceClient constructor.
+            @test contains(generated, "token=nothing,")
+            @test contains(generated, "token=token,")
             # Correct streaming type parameters for each RPC variant
             @test contains(
                 generated,
@@ -543,6 +552,44 @@ include("gen/test/test_pb.jl")
             client,
             TestRequest(1024, zeros(UInt64, 1)),
         )
+    end
+
+    @testset "Bearer Authentication" begin
+        # A client configured with the correct bearer token sends
+        # `authorization: Bearer <token>`, which the test server validates.
+        # A successful response proves the header reached the server intact.
+        client = TestService_TestRPC_Client(
+            _TEST_HOST,
+            _TEST_PORT;
+            token = _TEST_BEARER_TOKEN,
+        )
+        @test client.token == _TEST_BEARER_TOKEN
+
+        response = grpc_sync_request(client, TestRequest(1, zeros(UInt64, 1)))
+        @test length(response.data) == 1
+        @test response.data[1] == 1
+
+        # A wrong token is rejected by the server with UNAUTHENTICATED, proving
+        # the supplied token value is transmitted faithfully (not dropped).
+        bad_client = TestService_TestRPC_Client(
+            _TEST_HOST,
+            _TEST_PORT;
+            token = "wrong-token",
+        )
+        try
+            grpc_sync_request(bad_client, TestRequest(1, zeros(UInt64, 1)))
+            @test false  # Should not reach here
+        catch ex
+            @test isa(ex, gRPCServiceCallException)
+            @test ex.grpc_status == GRPC_UNAUTHENTICATED
+        end
+
+        # The default client sends no `authorization` header, so the server's
+        # auth check is bypassed and the request succeeds as before.
+        default_client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
+        @test isnothing(default_client.token)
+        response = grpc_sync_request(default_client, TestRequest(1, zeros(UInt64, 1)))
+        @test length(response.data) == 1
     end
 
     @testset "Graceful shutdown during concurrent requests" begin


### PR DESCRIPTION
Closes #56. Adds an optional `token` keyword to the service client; when set, every request (unary and streaming) sends an `authorization: Bearer <token>` header, and when left as `nothing` no header is sent so existing behavior is unchanged. The token threads through the generated `*_Client` constructors, `gRPCServiceClient`, and the request builder, matching how the existing `deadline`/`keepalive` options flow.

The Go test server gains a unary interceptor and a new `Bearer Authentication` testset asserting the correct token is accepted, a wrong token is rejected with `UNAUTHENTICATED`, and the default no-token client is unaffected.

Note: `test/gen/test/test_pb.jl` is a generated artifact — the 8 `token` lines were inserted by hand in formatter style to avoid whitespace churn; `src/ProtoBuf.jl` is the source of truth and is covered by the Code Generation testset.