### PR TITLE
Timeout header should NOT exceed 8 digits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "gRPCClient"
 uuid = "aaca4a50-36af-4a1d-b878-4c443f2061ad"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Carroll Vance <cs.vance@icloud.com>"]
 
 [deps]

--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -161,7 +161,14 @@ end
 # 29.999999046 -> "29999999046n" which the peer rejects as malformed), round UP to the finest unit
 # that does fit, keeping the header spec-valid and never encoding a shorter timeout than requested.
 function grpc_timeout_header_val(timeout::Real)
-    timeout < 0 && return "0n"
+    # A negative, non-finite, or unrepresentably-large timeout is a caller error: reject it with
+    # INVALID_ARGUMENT rather than silently coerce it into a wrong deadline on the wire.
+    (isfinite(timeout) && timeout >= 0) || throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
+        "grpc-timeout must be a finite, non-negative number of seconds, got $(timeout)"))
+    # Nanoseconds is the finest unit; a timeout beyond what fits in Int64 ns (~292 years) cannot be
+    # represented, so reject it here rather than overflow the conversion below.
+    timeout * 1e9 >= typemax(Int64) && throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
+        "grpc-timeout $(timeout)s is too large to encode as a grpc-timeout header"))
     ns = round(Int64, timeout * 1_000_000_000)
     # Coarsest-exact preference: seconds, milliseconds, microseconds, nanoseconds.
     for (mult, unit) in ((1_000_000_000, 'S'), (1_000_000, 'm'), (1_000, 'u'), (1, 'n'))
@@ -174,7 +181,9 @@ function grpc_timeout_header_val(timeout::Real)
         ticks = cld(ns, mult)
         ticks <= 99_999_999 && return "$(ticks)$(unit)"
     end
-    return "99999999H"  # unreachable for any realistic timeout
+    # A valid Int64 ns always fits in <=8 hour-digits, so reaching here is a logic error, not input.
+    throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
+        "grpc-timeout $(timeout)s could not be encoded within the 8-digit gRPC limit"))
 end
 
 

--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -165,11 +165,19 @@ function grpc_timeout_header_val(timeout::Real)
     # INVALID_ARGUMENT rather than silently coerce it into a wrong deadline on the wire.
     (isfinite(timeout) && timeout >= 0) || throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
         "grpc-timeout must be a finite, non-negative number of seconds, got $(timeout)"))
-    # Nanoseconds is the finest unit; a timeout beyond what fits in Int64 ns (~292 years) cannot be
-    # represented, so reject it here rather than overflow the conversion below.
-    timeout * 1e9 >= typemax(Int64) && throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
+    # Convert to Float64 before scaling to nanoseconds. A narrow Real (e.g. Float16, whose max is
+    # 65504) would otherwise promote the 1e9 factor into its own type and overflow to Inf, corrupting
+    # the conversion; a too-large finite input (e.g. a huge BigFloat) converts to Inf and is caught
+    # by the range check below. Nanoseconds is the finest unit, so a value beyond what fits in Int64
+    # ns (~292 years) cannot be represented.
+    t = Float64(timeout)
+    t * 1e9 < typemax(Int64) || throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
         "grpc-timeout $(timeout)s is too large to encode as a grpc-timeout header"))
-    ns = round(Int64, timeout * 1_000_000_000)
+    # Round to the nearest nanosecond (absorbs floating-point representation error, so clean inputs
+    # stay exact, e.g. 0.001 -> "1m"). A strictly positive timeout must never collapse to "0S", which
+    # would encode an already-expired deadline, so floor it at a single nanosecond.
+    ns = round(Int64, t * 1e9)
+    ns == 0 && t > 0 && (ns = 1)
     # Coarsest-exact preference: seconds, milliseconds, microseconds, nanoseconds.
     for (mult, unit) in ((1_000_000_000, 'S'), (1_000_000, 'm'), (1_000, 'u'), (1, 'n'))
         q, r = divrem(ns, mult)

--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -179,15 +179,17 @@ function grpc_timeout_header_val(timeout::Real)
     ns = round(Int64, t * 1e9)
     ns == 0 && t > 0 && (ns = 1)
     # Coarsest-exact preference: seconds, milliseconds, microseconds, nanoseconds.
+    # `string(q) * unit` (String * Char) rather than "$(q)$(unit)": interpolating a Char takes a
+    # slower path that allocates ~2.5x more, and this runs once per request.
     for (mult, unit) in ((1_000_000_000, 'S'), (1_000_000, 'm'), (1_000, 'u'), (1, 'n'))
         q, r = divrem(ns, mult)
-        r == 0 && q <= 99_999_999 && return "$(q)$(unit)"
+        r == 0 && q <= 99_999_999 && return string(q) * unit
     end
     # No exact unit fits in 8 digits: round up to the finest unit that does (nanoseconds .. hours).
     for (mult, unit) in ((1, 'n'), (1_000, 'u'), (1_000_000, 'm'), (1_000_000_000, 'S'),
                          (60_000_000_000, 'M'), (3_600_000_000_000, 'H'))
         ticks = cld(ns, mult)
-        ticks <= 99_999_999 && return "$(ticks)$(unit)"
+        ticks <= 99_999_999 && return string(ticks) * unit
     end
     # A valid Int64 ns always fits in <=8 hour-digits, so reaching here is a logic error, not input.
     throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,

--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -153,24 +153,28 @@ function header_callback(
     end
 end
 
+# Render a timeout (seconds) as a gRPC `grpc-timeout` header value. Per the gRPC HTTP/2 spec the
+# value is a positive integer of AT MOST 8 digits followed by a unit char (H/M/S/m/u/n). Prefer the
+# coarsest unit from seconds down to nanoseconds that represents the timeout exactly within 8 digits,
+# so common values stay compact ("1S", "500m", "100n"). When no exact representation fits in 8 digits
+# (a fractional multi-second timeout, whose exact form needs more than 8 nanosecond digits, e.g.
+# 29.999999046 -> "29999999046n" which the peer rejects as malformed), round UP to the finest unit
+# that does fit, keeping the header spec-valid and never encoding a shorter timeout than requested.
 function grpc_timeout_header_val(timeout::Real)
-    if round(Int, timeout) == timeout
-        timeout_secs = round(Int64, timeout)
-        return "$(string(timeout_secs))S"
+    timeout < 0 && return "0n"
+    ns = round(Int64, timeout * 1_000_000_000)
+    # Coarsest-exact preference: seconds, milliseconds, microseconds, nanoseconds.
+    for (mult, unit) in ((1_000_000_000, 'S'), (1_000_000, 'm'), (1_000, 'u'), (1, 'n'))
+        q, r = divrem(ns, mult)
+        r == 0 && q <= 99_999_999 && return "$(q)$(unit)"
     end
-    timeout *= 1000
-    if round(Int, timeout) == timeout
-        timeout_millisecs = round(Int64, timeout)
-        return "$(string(timeout_millisecs))m"
+    # No exact unit fits in 8 digits: round up to the finest unit that does (nanoseconds .. hours).
+    for (mult, unit) in ((1, 'n'), (1_000, 'u'), (1_000_000, 'm'), (1_000_000_000, 'S'),
+                         (60_000_000_000, 'M'), (3_600_000_000_000, 'H'))
+        ticks = cld(ns, mult)
+        ticks <= 99_999_999 && return "$(ticks)$(unit)"
     end
-    timeout *= 1000
-    if round(Int, timeout) == timeout
-        timeout_microsecs = round(Int64, timeout)
-        return "$(string(timeout_microsecs))u"
-    end
-    timeout *= 1000
-    timeout_nanosecs = round(Int64, timeout)
-    return "$(string(timeout_nanosecs))n"
+    return "99999999H"  # unreachable for any realistic timeout
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -575,6 +575,26 @@ include("gen/test/test_pb.jl")
 
         @testset "edge cases" begin
             @test grpc_timeout_header_val(0) == "0S"     # zero is valid: immediate deadline
+            # A strictly positive timeout must never round DOWN to "0S" (already-expired). Values
+            # below half a nanosecond floor at one nanosecond instead of collapsing to zero.
+            @test grpc_timeout_header_val(1e-10) == "1n"
+            @test grpc_timeout_header_val(4e-10) == "1n"
+            @test grpc_timeout_header_val(1e-12) == "1n"
+        end
+
+        @testset "narrow and exotic Real types" begin
+            # The `::Real` signature must handle any numeric type. In particular a narrow float must
+            # not overflow the ns scale factor to Inf and crash with InexactError.
+            @test grpc_timeout_header_val(Float16(1.0)) == "1S"
+            @test grpc_timeout_header_val(Float16(0.0)) == "0S"
+            @test grpc_timeout_header_val(Float32(2.5)) == "2500m"
+            @test grpc_timeout_header_val(1) == "1S"            # Int
+            @test grpc_timeout_header_val(true) == "1S"         # Bool
+            @test grpc_timeout_header_val(big(5)) == "5S"       # BigInt
+            @test grpc_timeout_header_val(1 // 2) == "500m"     # Rational
+            # Well-formed (not necessarily exact) for irrationals and big floats.
+            @test is_wellformed(grpc_timeout_header_val(float(pi)))
+            @test is_wellformed(grpc_timeout_header_val(big"1.5"))
         end
 
         @testset "invalid input throws INVALID_ARGUMENT" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -574,8 +574,22 @@ include("gen/test/test_pb.jl")
         end
 
         @testset "edge cases" begin
-            @test grpc_timeout_header_val(0) == "0S"
-            @test grpc_timeout_header_val(-1) == "0n"    # negative is clamped, never signed
+            @test grpc_timeout_header_val(0) == "0S"     # zero is valid: immediate deadline
+        end
+
+        @testset "invalid input throws INVALID_ARGUMENT" begin
+            # A bad timeout is a caller error and must surface as a gRPC INVALID_ARGUMENT exception,
+            # never be silently coerced into a wrong (clamped) deadline on the wire.
+            invalid_arg(f) = try
+                f(); nothing
+            catch e
+                e isa gRPCServiceCallException && e.grpc_status == gRPCClient.GRPC_INVALID_ARGUMENT
+            end
+            @test invalid_arg(() -> grpc_timeout_header_val(-1))          # negative
+            @test invalid_arg(() -> grpc_timeout_header_val(-1e-9))       # negative, sub-nanosecond
+            @test invalid_arg(() -> grpc_timeout_header_val(Inf))         # non-finite
+            @test invalid_arg(() -> grpc_timeout_header_val(NaN))         # non-finite
+            @test invalid_arg(() -> grpc_timeout_header_val(1e12))        # beyond Int64 ns (~292y)
         end
 
         @testset "invariants over a wide sweep" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -518,20 +518,79 @@ include("gen/test/test_pb.jl")
         end
     end
 
-    # @testset "Timeout Header Value Formatting" begin
-    # Test integer seconds
-    @test grpc_timeout_header_val(1) == "1S"
+    @testset "grpc-timeout header value formatting" begin
+        # Per the gRPC HTTP/2 spec, a grpc-timeout value is a positive integer of at most 8 digits
+        # followed by a unit char: H (hour), M (minute), S (second), m (ms), u (us), n (ns).
+        _UNIT_NS = Dict('H' => 3_600_000_000_000, 'M' => 60_000_000_000, 'S' => 1_000_000_000,
+                        'm' => 1_000_000, 'u' => 1_000, 'n' => 1)
+        # Decode a header value back to seconds so we can check it never encodes a shorter timeout.
+        decode_s(hv) = parse(Int64, hv[1:end-1]) * _UNIT_NS[hv[end]] / 1e9
+        # Assert the value obeys the spec: 1-8 ASCII digits then a known unit char.
+        function is_wellformed(hv)
+            length(hv) >= 2 || return false
+            haskey(_UNIT_NS, hv[end]) || return false
+            digits = hv[1:end-1]
+            1 <= length(digits) <= 8 && all(isdigit, digits)
+        end
 
-    # Test milliseconds
-    @test grpc_timeout_header_val(0.001) == "1m"
+        @testset "exact whole units" begin
+            # Whole seconds render as S.
+            @test grpc_timeout_header_val(1) == "1S"
+            @test grpc_timeout_header_val(5) == "5S"
+            @test grpc_timeout_header_val(60) == "60S"      # S is preferred over M
+            @test grpc_timeout_header_val(3600) == "3600S"  # S is preferred over H
+            # Whole milliseconds render as m.
+            @test grpc_timeout_header_val(0.001) == "1m"
+            @test grpc_timeout_header_val(0.1) == "100m"
+            # Whole microseconds render as u.
+            @test grpc_timeout_header_val(0.000001) == "1u"
+            @test grpc_timeout_header_val(0.0005) == "500u"
+            # Whole nanoseconds render as n.
+            @test grpc_timeout_header_val(0.0000001) == "100n"
+            @test grpc_timeout_header_val(1e-9) == "1n"
+        end
 
-    # Test microseconds
-    @test grpc_timeout_header_val(0.000001) == "1u"
+        @testset "coarsest exact unit is preferred" begin
+            # A value expressible in several units picks the coarsest (fewest ticks), not the finest.
+            @test grpc_timeout_header_val(1) == "1S"       # not "1000m"
+            @test grpc_timeout_header_val(0.5) == "500m"   # not "500000u"
+            @test grpc_timeout_header_val(2.5) == "2500m"  # not "2500000u"
+        end
 
-    # Test nanoseconds
-    @test grpc_timeout_header_val(0.0000001) == "100n"
+        @testset "8-digit boundary is exact" begin
+            # The largest value representable in each unit within 8 digits stays in that unit.
+            @test grpc_timeout_header_val(99_999_999) == "99999999S"        # 99999999 whole seconds
+            @test grpc_timeout_header_val(0.099999999) == "99999999n"       # 99999999 ns
+        end
 
-    # end
+        @testset "overflow rounds up to the finest fitting unit" begin
+            # A fractional multi-second timeout's exact form needs >8 nanosecond digits, which the
+            # peer rejects as malformed. It must round UP to the finest unit that fits in 8 digits.
+            @test grpc_timeout_header_val(29.999999046) == "30000000u"  # was the 11-digit "29999999046n" bug
+            @test grpc_timeout_header_val(10.0000001) == "10000001u"
+            @test grpc_timeout_header_val(123.4567) == "123457m"
+            # Absurdly large whole-second value overflows S and steps up to minutes.
+            @test grpc_timeout_header_val(100_000_000) == "1666667M"
+        end
+
+        @testset "edge cases" begin
+            @test grpc_timeout_header_val(0) == "0S"
+            @test grpc_timeout_header_val(-1) == "0n"    # negative is clamped, never signed
+        end
+
+        @testset "invariants over a wide sweep" begin
+            # For every timeout, the header must be well-formed (<=8 digits + valid unit) and must
+            # never encode a SHORTER timeout than requested (rounding is always up).
+            vals = Float64[0, 1e-9, 5e-9, 1e-7, 0.0005, 0.05, 0.099999999, 0.1, 0.5, 1, 2.5,
+                           9.9999999, 10.0000001, 29.999999046, 60, 90.0001, 123.4567, 3600,
+                           99_999.9994, 1e6 + 0.5, 99_999_999]
+            for t in vals
+                hv = grpc_timeout_header_val(t)
+                @test is_wellformed(hv)
+                @test decode_s(hv) >= t - 1e-9
+            end
+        end
+    end
 
     @testset "Max Message Size" begin
         # Create a client with much more restictive max message lengths


### PR DESCRIPTION
For some timeout values, more than 8 digits was used which violates the gRPC spec. We should always round to the nearest representation that has 8 digits or less. 