### PR TITLE
Use Runic.jl as our formatter

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,29 @@
+name: Format
+
+# Runic formatting check. Kept separate from ci.yml so it runs on any Julia
+# source change, including docs and utils, which the test matrix skips.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '**/*.jl'
+      - '.github/workflows/format.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '**/*.jl'
+      - '.github/workflows/format.yml'
+
+jobs:
+  runic:
+    name: Runic
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: '1'
+    - uses: julia-actions/cache@v2
+    - uses: fredrikekre/runic-action@v1
+      with:
+        version: '1'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to gRPCClient.jl
+
+Thanks for your interest in improving gRPCClient.jl. Issues and pull requests are welcome.
+
+## Formatting
+
+This repository is formatted with [Runic.jl](https://github.com/fredrikekre/Runic.jl). Please run the
+formatter over your changes before opening a pull request, so that diffs stay free of unrelated
+whitespace churn.
+
+Install it once as an app, from the Julia Pkg REPL:
+
+```
+] app add Runic
+```
+
+Then format the repository in place, from the repository root:
+
+```bash
+runic --inplace .
+```
+
+To check without writing, which is what a reviewer will do, swap `--inplace` for `--check --diff`.
+Runic has no configuration, so there is nothing to tune: whatever it emits is the house style.
+
+App installation needs Julia 1.12 or newer, and `~/.julia/bin` on your `PATH`. On an older Julia,
+`julia --project=@runic -e 'using Runic; exit(Runic.main(ARGS))' -- --inplace .` does the same thing
+against an environment you have added Runic to.
+
+CI runs the same check on every pull request that touches a `.jl` file, so an unformatted branch
+shows up as a red Format job.
+
+If you would rather catch it before pushing, Runic ships editor integrations, and a git hook is a
+few lines. Put this in `.git/hooks/pre-commit` and make it executable; the file is local to your
+clone and is not tracked:
+
+```bash
+#!/usr/bin/env bash
+exec 1>&2
+set -o pipefail
+git diff --cached -z --name-only --diff-filter=ACM -- '*.jl' \
+    | xargs -0 --no-run-if-empty runic --check --diff
+```
+
+Then `chmod +x .git/hooks/pre-commit`. The hook prints a diff and aborts the commit when a staged
+Julia file is unformatted; `runic --inplace .` fixes it, and `git commit --no-verify` skips the check
+for a single commit. Note that it reads the working tree copy rather than the staged blob, so a
+partially staged file is judged by its full contents.
+
+## Tests
+
+The suite runs against the Go reference server in `test/go`. Build it first, then let the suite
+manage its lifetime:
+
+```bash
+cd test/go && go build -o grpc_test_server && cd ../..
+JULIA_GRPCCLIENT_TEST_START_SERVER=go julia --project test/runtests.jl
+```
+
+If you already have a server listening on `localhost:8001`, plain `julia --project test/runtests.jl`
+is enough. `GRPC_TEST_SERVER_HOST` and `GRPC_TEST_SERVER_PORT` point the suite elsewhere.
+
+CI covers Julia 1.10, 1.12, and nightly across Linux, Windows, and macOS. Note that
+`src/Streaming.jl` is compiled only on Julia 1.12 and newer, so streaming code and its tests need
+matching version guards.
+
+## Pull requests
+
+- Keep the change focused, and describe what it does and why in the PR body
+- Add or extend tests in `test/runtests.jl` for behavior changes, including the failure paths
+- If you change `src/ProtoBuf.jl`, regenerate the checked-in stubs with `bash protoc.sh` from `test`,
+  since the `Code Generation` testset asserts on the generated text
+- If you change a public method signature, update the `@docs` blocks in `docs/src/index.md`, which
+  Documenter builds strictly
+- The `skills/` directory is the authoritative reference for library behavior; update it when
+  behavior changes

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This library ships agent skills. In Claude Code:
 
 That installs `grpcclient-jl` for calling gRPC services and `grpcclient-jl-dev` for working on the package itself. Both live in [`skills/`](skills) as plain Markdown and are the authoritative reference for how this library behaves.
 
+## Contributing
+
+Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to run the test suite and for the formatting requirement: contributed code must be formatted with [Runic.jl](https://github.com/fredrikekre/Runic.jl).
+
 ## Benchmarks
 
 Benchmarking, stress-testing, and profiling utilities live in [`utils/gRPCClientUtils.jl`](utils/gRPCClientUtils.jl). Run `benchmark_table()` against the test server in `test/go` to measure throughput, latency, and allocations per workload on your own hardware.

--- a/skills/grpcclient-jl-dev/SKILL.md
+++ b/skills/grpcclient-jl-dev/SKILL.md
@@ -23,6 +23,20 @@ description: Work on the gRPCClient.jl package itself. Covers running the Go tes
 
 Streaming is conditionally compiled: `src/Streaming.jl` is included only under `@static if VERSION >= v"1.12"`, so anything added there needs a matching version guard in the tests.
 
+## Formatting
+
+The repository is formatted with [Runic.jl](https://github.com/fredrikekre/Runic.jl), and contributed code is expected to be run through it before a pull request goes up:
+
+```
+] app add Runic          # once, Julia 1.12 or newer
+```
+
+```bash
+runic --inplace .        # from the repository root
+```
+
+Use `--check --diff` in place of `--inplace` to verify without writing. Runic takes no configuration. `CONTRIBUTING.md` states this for human contributors.
+
 ## Test server
 
 ```bash

--- a/src/Curl.jl
+++ b/src/Curl.jl
@@ -21,11 +21,11 @@ Base.iterate(req::NoChannel) =
 
 
 function write_callback(
-    data::Ptr{Cchar},
-    size::Csize_t,
-    count::Csize_t,
-    req_p::Ptr{Cvoid},
-)::Csize_t
+        data::Ptr{Cchar},
+        size::Csize_t,
+        count::Csize_t,
+        req_p::Ptr{Cvoid},
+    )::Csize_t
     try
         req = unsafe_pointer_to_objref(req_p)::gRPCRequest
 
@@ -57,7 +57,7 @@ function write_callback(
         !isnothing(req.ex) && return typemax(Csize_t)
 
         # Check that we handled the correct number of bytes
-        # If there was no exception in handle_write this should always match 
+        # If there was no exception in handle_write this should always match
         if handled_n_bytes_total != n
             handle_exception(
                 req,
@@ -80,11 +80,11 @@ function write_callback(
 end
 
 function read_callback(
-    data::Ptr{Cchar},
-    size::Csize_t,
-    count::Csize_t,
-    req_p::Ptr{Cvoid},
-)::Csize_t
+        data::Ptr{Cchar},
+        size::Csize_t,
+        count::Csize_t,
+        req_p::Ptr{Cvoid},
+    )::Csize_t
     try
         req = unsafe_pointer_to_objref(req_p)::gRPCRequest
 
@@ -112,7 +112,7 @@ function read_callback(
             truncate(req.request, 0)
             req.request_ptr = 0
 
-            # Safe to write more data to the request buffer again 
+            # Safe to write more data to the request buffer again
             notify(req.curl_done_reading)
 
             return CURL_READFUNC_PAUSE
@@ -130,11 +130,11 @@ const regex_grpc_message = Regex("grpc-message: (.*)", "s")
 
 
 function header_callback(
-    data::Ptr{Cchar},
-    size::Csize_t,
-    count::Csize_t,
-    req_p::Ptr{Cvoid},
-)::Csize_t
+        data::Ptr{Cchar},
+        size::Csize_t,
+        count::Csize_t,
+        req_p::Ptr{Cvoid},
+    )::Csize_t
     try
         req = unsafe_pointer_to_objref(req_p)::gRPCRequest
         n = size * count
@@ -171,20 +171,28 @@ end
 function grpc_timeout_header_val(timeout::Real)
     # A negative, non-finite, or unrepresentably-large timeout is a caller error: reject it with
     # INVALID_ARGUMENT rather than silently coerce it into a wrong deadline on the wire.
-    (isfinite(timeout) && timeout >= 0) || throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
-        "grpc-timeout must be a finite, non-negative number of seconds, got $(timeout)"))
+    (isfinite(timeout) && timeout >= 0) || throw(
+        gRPCServiceCallException(
+            GRPC_INVALID_ARGUMENT,
+            "grpc-timeout must be a finite, non-negative number of seconds, got $(timeout)"
+        )
+    )
     # Convert to Float64 before scaling to nanoseconds. A narrow Real (e.g. Float16, whose max is
     # 65504) would otherwise promote the 1e9 factor into its own type and overflow to Inf, corrupting
     # the conversion; a too-large finite input (e.g. a huge BigFloat) converts to Inf and is caught
     # by the range check below. Nanoseconds is the finest unit, so a value beyond what fits in Int64
     # ns (~292 years) cannot be represented.
     t = Float64(timeout)
-    t * 1e9 < typemax(Int64) || throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
-        "grpc-timeout $(timeout)s is too large to encode as a grpc-timeout header"))
+    t * 1.0e9 < typemax(Int64) || throw(
+        gRPCServiceCallException(
+            GRPC_INVALID_ARGUMENT,
+            "grpc-timeout $(timeout)s is too large to encode as a grpc-timeout header"
+        )
+    )
     # Round to the nearest nanosecond (absorbs floating-point representation error, so clean inputs
     # stay exact, e.g. 0.001 -> "1m"). A strictly positive timeout must never collapse to "0S", which
     # would encode an already-expired deadline, so floor it at a single nanosecond.
-    ns = round(Int64, t * 1e9)
+    ns = round(Int64, t * 1.0e9)
     ns == 0 && t > 0 && (ns = 1)
     # Coarsest-exact preference: seconds, milliseconds, microseconds, nanoseconds.
     # `string(q) * unit` (String * Char) rather than "$(q)$(unit)": interpolating a Char takes a
@@ -194,14 +202,20 @@ function grpc_timeout_header_val(timeout::Real)
         r == 0 && q <= 99_999_999 && return string(q) * unit
     end
     # No exact unit fits in 8 digits: round up to the finest unit that does (nanoseconds .. hours).
-    for (mult, unit) in ((1, 'n'), (1_000, 'u'), (1_000_000, 'm'), (1_000_000_000, 'S'),
-                         (60_000_000_000, 'M'), (3_600_000_000_000, 'H'))
+    for (mult, unit) in (
+            (1, 'n'), (1_000, 'u'), (1_000_000, 'm'), (1_000_000_000, 'S'),
+            (60_000_000_000, 'M'), (3_600_000_000_000, 'H'),
+        )
         ticks = cld(ns, mult)
         ticks <= 99_999_999 && return string(ticks) * unit
     end
     # A valid Int64 ns always fits in <=8 hour-digits, so reaching here is a logic error, not input.
-    throw(gRPCServiceCallException(GRPC_INVALID_ARGUMENT,
-        "grpc-timeout $(timeout)s could not be encoded within the 8-digit gRPC limit"))
+    throw(
+        gRPCServiceCallException(
+            GRPC_INVALID_ARGUMENT,
+            "grpc-timeout $(timeout)s could not be encoded within the 8-digit gRPC limit"
+        )
+    )
 end
 
 const _AUTHORIZATION_HEADER = "authorization"
@@ -216,7 +230,7 @@ const _AUTHORIZATION_HEADER = "authorization"
 #
 # Allocation-free by construction: `keys` on a Dict is a lazy KeySet, and comparing with
 # `codeunit` reads bytes in place rather than building a lowercased copy of each key.
-function _has_authorization_key(metadata::Dict{String,String})
+function _has_authorization_key(metadata::Dict{String, String})
     n = ncodeunits(_AUTHORIZATION_HEADER)
     for k in keys(metadata)
         ncodeunits(k) == n || continue
@@ -237,8 +251,8 @@ end
     max_recieve_message_length::Int = 4 * 1024 * 1024
     # Optional bearer token attached to every request as an
     # `authorization: Bearer <token>` header. `nothing` sends no header.
-	# Note that this is equivalent to adding "authorization" => "Bearer $token"
-	# to metadata
+    # Note that this is equivalent to adding "authorization" => "Bearer $token"
+    # to metadata
     token::Union{Nothing, String} = nothing
     metadata::Union{Nothing, Dict{String, String}} = nothing
 
@@ -253,22 +267,22 @@ end
     # To swap a client-level token for per-request metadata, pass `token = nothing`
     # alongside the metadata override.
     function gRPCConnectionOptions(
-        secure,
-        deadline,
-        keepalive,
-        max_send_message_length,
-        max_recieve_message_length,
-        token,
-        metadata,
-    )
+            secure,
+            deadline,
+            keepalive,
+            max_send_message_length,
+            max_recieve_message_length,
+            token,
+            metadata,
+        )
         if !isnothing(token) &&
-           !isnothing(metadata) &&
-           _has_authorization_key(metadata)
+                !isnothing(metadata) &&
+                _has_authorization_key(metadata)
             throw(
                 gRPCServiceCallException(
                     GRPC_INVALID_ARGUMENT,
                     "token and an \"authorization\" metadata entry both set the authorization header; " *
-                    "use one or the other (pass token = nothing to override a client-level token with metadata)",
+                        "use one or the other (pass token = nothing to override a client-level token with metadata)",
                 ),
             )
         end
@@ -284,10 +298,10 @@ end
     end
 end
 
-# Creates a new options object (if necessary) where some fields are overridden 
+# Creates a new options object (if necessary) where some fields are overridden
 # based on overrides
 @generated function _merge_options(options::gRPCConnectionOptions, overrides::AbstractDict)::gRPCConnectionOptions
-    # if no argument is overriden, just return options. 
+    # if no argument is overriden, just return options.
     # Otherwise, create a new object with some fields overridden
     return quote
         $(Expr(:meta, :inline)) # Equivalent of @inline for generated functions
@@ -298,14 +312,16 @@ end
             end
         end
         gRPCConnectionOptions(
-            $([
-                # Generate 
-                # get(overrides, :field1, options.field1)
-                # get(overrides, :field2, options.field2)
-                # ...
-                # for each fieldname of gRPCConnectionOptions
-                :(get(overrides, $(QuoteNode(fn)), options.$fn)) 
-                    for fn in fieldnames(gRPCConnectionOptions) if fn != :metadata]...
+            $(
+                [
+                    # Generate
+                    # get(overrides, :field1, options.field1)
+                    # get(overrides, :field2, options.field2)
+                    # ...
+                    # for each fieldname of gRPCConnectionOptions
+                    :(get(overrides, $(QuoteNode(fn)), options.$fn))
+                        for fn in fieldnames(gRPCConnectionOptions) if fn != :metadata
+                ]...
             ),
             # For metadata, we override on a per-field basis instead
             if :metadata in keys(overrides) && !isnothing(overrides[:metadata])
@@ -338,7 +354,7 @@ mutable struct gRPCRequest
     # CURL headers list
     headers::Ptr{Cvoid}
 
-    # The full request URL 
+    # The full request URL
     url::String
 
     # Contains the request data which will be uploaded in read_callback
@@ -351,8 +367,8 @@ mutable struct gRPCRequest
     response::IOBuffer
 
     # These are only used when the request or response is streaming
-    request_c::Union{Channel{IOBuffer},NoChannel}
-    response_c::Union{Channel{IOBuffer},NoChannel}
+    request_c::Union{Channel{IOBuffer}, NoChannel}
+    response_c::Union{Channel{IOBuffer}, NoChannel}
 
     # The task making the request can block on this until the request is complete
     ready::Event
@@ -366,7 +382,7 @@ mutable struct gRPCRequest
     max_recieve_message_length::Int64
 
     # Contains the first exception if any encountered during the request
-    ex::Union{Nothing,Exception}
+    ex::Union{Nothing, Exception}
 
     # Keeps track of the response stream parsing state
     response_read_header::Bool
@@ -389,18 +405,18 @@ mutable struct gRPCRequest
     completed::Bool
 
     # Client-side deadline watchdog, see the comment in the constructor
-    timer::Union{Nothing,Timer}
+    timer::Union{Nothing, Timer}
 
     function gRPCRequest(
-        grpc,
-        url::String,
-        request::IOBuffer,
-        response::IOBuffer,
-        request_c::Union{Channel{IOBuffer},NoChannel},
-        response_c::Union{Channel{IOBuffer},NoChannel},
-        options::gRPCConnectionOptions;
-        kws...
-    )
+            grpc,
+            url::String,
+            request::IOBuffer,
+            response::IOBuffer,
+            request_c::Union{Channel{IOBuffer}, NoChannel},
+            response_c::Union{Channel{IOBuffer}, NoChannel},
+            options::gRPCConnectionOptions;
+            kws...
+        )
 
         options = _merge_options(options, kws)
 
@@ -685,15 +701,15 @@ mutable struct gRPCRequest
     # max_streams slot, is never added to grpc.requests, and is already marked
     # completed so cleanup_request and grpc_cancel are no-ops on it.
     function gRPCRequest(
-        grpc,
-        url::String,
-        request::IOBuffer,
-        response::IOBuffer,
-        request_c::Union{Channel{IOBuffer},NoChannel},
-        response_c::Union{Channel{IOBuffer},NoChannel},
-        ex::Exception,
-        options::gRPCConnectionOptions,
-    )
+            grpc,
+            url::String,
+            request::IOBuffer,
+            response::IOBuffer,
+            request_c::Union{Channel{IOBuffer}, NoChannel},
+            response_c::Union{Channel{IOBuffer}, NoChannel},
+            ex::Exception,
+            options::gRPCConnectionOptions,
+        )
         req = new(
             grpc.lock,
             Ptr{Cvoid}(0),
@@ -735,7 +751,7 @@ end
 function handle_exception(req::gRPCRequest, ex; notify_ready = false)
     # We want to record the *first* exception a request encounters
     # This helps identify the root cause of why something failed
-    if isnothing(req.ex)
+    return if isnothing(req.ex)
         req.ex = ex
         notify_ready && notify(req.ready)
     end
@@ -767,9 +783,9 @@ function complete_streaming_message!(req::gRPCRequest)
 end
 
 function handle_write(
-    req::gRPCRequest,
-    buf::Vector{UInt8},
-)::Tuple{Int64,Union{Nothing,Vector{UInt8}}}
+        req::gRPCRequest,
+        buf::Vector{UInt8},
+    )::Tuple{Int64, Union{Nothing, Vector{UInt8}}}
     if !req.response_read_header
         header_bytes_left = GRPC_HEADER_SIZE - req.response.size
 
@@ -925,7 +941,7 @@ mutable struct CURLWatcher
     function CURLWatcher(sock, fdw)
         event = Event()
         notify(event)
-        new(sock, fdw, event, true)
+        return new(sock, fdw, event, true)
     end
 end
 
@@ -934,17 +950,17 @@ Base.iswritable(w::CURLWatcher) = w.fdw.writable
 function Base.close(w::CURLWatcher)
     w.running = false
     notify(w.ready)
-    close(w.fdw)
+    return close(w.fdw)
 end
 
 
 function socket_callback(
-    easy_h::Ptr{Cvoid},
-    sock::curl_socket_t,
-    action::Cint,
-    grpc_p::Ptr{Cvoid},
-    socket_p::Ptr{Cvoid},
-)::Cint
+        easy_h::Ptr{Cvoid},
+        sock::curl_socket_t,
+        action::Cint,
+        grpc_p::Ptr{Cvoid},
+        socket_p::Ptr{Cvoid},
+    )::Cint
     try
         if action ∉ (CURL_POLL_IN, CURL_POLL_OUT, CURL_POLL_INOUT, CURL_POLL_REMOVE)
             @error("socket_callback: unexpected action", action, maxlog = 1_000)
@@ -1075,7 +1091,7 @@ function grpc_multi_init(grpc)
         (Ptr{Cvoid}, curl_socket_t, Cint, Ptr{Cvoid}, Ptr{Cvoid})
     )
     curl_multi_setopt(grpc.multi, CURLMOPT_SOCKETFUNCTION, socket_cb)
-    curl_multi_setopt(grpc.multi, CURLMOPT_SOCKETDATA, grpc_p)
+    return curl_multi_setopt(grpc.multi, CURLMOPT_SOCKETDATA, grpc_p)
 end
 
 
@@ -1084,8 +1100,8 @@ mutable struct gRPCCURL
     multi::Ptr{Cvoid}
     # *ALL* operations on the multi handle, any easy handles added to the multi, or this struct must acquire this lock.
     lock::ReentrantLock
-    timer::Union{Nothing,Timer}
-    watchers::Dict{curl_socket_t,CURLWatcher}
+    timer::Union{Nothing, Timer}
+    watchers::Dict{curl_socket_t, CURLWatcher}
     # Reduce lock contention by giving watchers their own lock
     watchers_lock::ReentrantLock
     running::Bool
@@ -1105,15 +1121,15 @@ mutable struct gRPCCURL
     sticky::Bool
 
     function gRPCCURL(;
-        max_streams::Int = GRPC_MAX_STREAMS,
-        running = true,
-        sticky::Bool = false,
-    )
+            max_streams::Int = GRPC_MAX_STREAMS,
+            running = true,
+            sticky::Bool = false,
+        )
         grpc = new(
             Ptr{Cvoid}(0),
             ReentrantLock(),
             nothing,
-            Dict{curl_socket_t,CURLWatcher}(),
+            Dict{curl_socket_t, CURLWatcher}(),
             ReentrantLock(),
             running,
             Vector{gRPCRequest}(),
@@ -1196,19 +1212,19 @@ function Base.close(grpc::gRPCCURL)
 
     unpreserve_handle(grpc)
 
-    nothing
+    return nothing
 end
 
 function Base.open(grpc::gRPCCURL)
-    lock(grpc.lock) do
+    return lock(grpc.lock) do
         if grpc.multi == Ptr{Cvoid}(0)
             lock(grpc.watchers_lock) do
                 # Guarantee that we start with a clean slate
-                grpc.watchers = Dict{curl_socket_t,CURLWatcher}()
+                grpc.watchers = Dict{curl_socket_t, CURLWatcher}()
             end
 
             lock(grpc.sem_cond) do
-                grpc.sem_free = Event[Event() for _ = 1:grpc.max_streams]
+                grpc.sem_free = Event[Event() for _ in 1:grpc.max_streams]
             end
 
             grpc.requests = Vector{gRPCRequest}()
@@ -1227,7 +1243,7 @@ end
 # max_reqs_inc when a slot frees, by any request's deadline watchdog firing, and by
 # close(grpc), and re-check their own condition on every wake.
 function max_reqs_dec(grpc::gRPCCURL, expiry::Float64)
-    lock(grpc.sem_cond) do
+    return lock(grpc.sem_cond) do
         while isempty(grpc.sem_free)
             grpc.running || throw(
                 gRPCServiceCallException(
@@ -1254,11 +1270,11 @@ function max_reqs_inc(grpc::gRPCCURL, event::Event)
         # it takes the slot, notices, and returns it here, passing the wake-up on.
         notify(grpc.sem_cond; all = false)
     end
-    nothing
+    return nothing
 end
 
 function max_reqs_inc(grpc::gRPCCURL, req::gRPCRequest)
-    if isstreaming_request(req)
+    return if isstreaming_request(req)
         # The request-stream pump may still be waiting on (or about to wait on) this
         # request's curl_done_reading Event. Notify it so the pump wakes and observes
         # req.completed, and hand the freelist a fresh Event so a lingering pump can
@@ -1291,13 +1307,13 @@ function cleanup_request(grpc::gRPCCURL, req::gRPCRequest)
     curl_slist_free_all(req.headers)
     # Allow this to be GC now that there is no risk of use in C callback
     unpreserve_handle(req)
-    # Close streaming channels 
+    # Close streaming channels
     close(req.response_c)
     close(req.request_c)
     # Increment the request semaphore to allow more requests through
     max_reqs_inc(grpc, req)
     # Unblock anything waiting on the request
-    notify(req.ready)
+    return notify(req.ready)
 end
 
 """
@@ -1313,14 +1329,14 @@ cancellation and `false` when the request had already completed (or the handle w
 shut down), in which case nothing changes.
 """
 function grpc_cancel(
-    req::gRPCRequest,
-    ex::Exception = gRPCServiceCallException(
-        GRPC_CANCELLED,
-        "Request was cancelled by the client.",
-    ),
-)
+        req::gRPCRequest,
+        ex::Exception = gRPCServiceCallException(
+            GRPC_CANCELLED,
+            "Request was cancelled by the client.",
+        ),
+    )
     grpc = req.grpc::gRPCCURL
-    lock(grpc.lock) do
+    return lock(grpc.lock) do
         # Already completed, or the whole handle was shut down: nothing to cancel
         (req.completed || !grpc.running) && return false
 
@@ -1367,6 +1383,7 @@ function check_multi_info(grpc::gRPCCURL)
             @error("curl_multi_info_read: unknown message", message, maxlog = 1_000)
         end
     end
+    return
 end
 
 
@@ -1376,5 +1393,5 @@ function stoptimer!(grpc::gRPCCURL)
         grpc.timer = nothing
         close(t)
     end
-    nothing
+    return nothing
 end

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -47,6 +47,7 @@ function service_cb(io, t::CodeGenerators.ServiceType, ctx::CodeGenerators.Conte
         end
     end
 
+    return
 end
 
 import_cb(io, ctx, definitions) =

--- a/src/Streaming.jl
+++ b/src/Streaming.jl
@@ -1,9 +1,7 @@
-
-
 function grpc_async_stream_request(
-    req::gRPCRequest,
-    channel::Channel{TRequest},
-) where {TRequest<:Any}
+        req::gRPCRequest,
+        channel::Channel{TRequest},
+    ) where {TRequest <: Any}
     try
         encode_buf = IOBuffer()
         reqs_ready = 0
@@ -91,13 +89,13 @@ function grpc_async_stream_request(
         close(req.request_c)
     end
 
-    nothing
+    return nothing
 end
 
 function grpc_async_stream_response(
-    req::gRPCRequest,
-    channel::Channel{TResponse},
-) where {TResponse<:Any}
+        req::gRPCRequest,
+        channel::Channel{TResponse},
+    ) where {TResponse <: Any}
     try
         while isnothing(req.ex)
             response_buf = take!(req.response_c)
@@ -117,7 +115,7 @@ function grpc_async_stream_response(
         close(req.response_c)
     end
 
-    nothing
+    return nothing
 end
 
 """
@@ -153,10 +151,10 @@ test_response = grpc_async_await(client, req)
 ```
 """
 function grpc_async_request(
-    client::gRPCServiceClient{TRequest,true,TResponse,false},
-    request::Channel{TRequest};
-    options...
-) where {TRequest<:Any,TResponse<:Any}
+        client::gRPCServiceClient{TRequest, true, TResponse, false},
+        request::Channel{TRequest};
+        options...
+    ) where {TRequest <: Any, TResponse <: Any}
 
     req = gRPCRequest(
         client.grpc,
@@ -171,7 +169,7 @@ function grpc_async_request(
     request_task = _spawn(() -> grpc_async_stream_request(req, request), client)
     errormonitor(request_task)
 
-    req
+    return req
 end
 
 """
@@ -207,11 +205,11 @@ grpc_async_await(req)
 ```
 """
 function grpc_async_request(
-    client::gRPCServiceClient{TRequest,false,TResponse,true},
-    request::TRequest,
-    response::Channel{TResponse};
-    kws...
-) where {TRequest<:Any,TResponse<:Any}
+        client::gRPCServiceClient{TRequest, false, TResponse, true},
+        request::TRequest,
+        response::Channel{TResponse};
+        kws...
+    ) where {TRequest <: Any, TResponse <: Any}
 
     options = _merge_options(client.options, kws)
 
@@ -234,7 +232,7 @@ function grpc_async_request(
     response_task = _spawn(() -> grpc_async_stream_response(req, response), client)
     errormonitor(response_task)
 
-    req
+    return req
 end
 
 """
@@ -276,11 +274,11 @@ grpc_async_await(req)
 ```
 """
 function grpc_async_request(
-    client::gRPCServiceClient{TRequest,true,TResponse,true},
-    request::Channel{TRequest},
-    response::Channel{TResponse};
-    options...
-) where {TRequest<:Any,TResponse<:Any}
+        client::gRPCServiceClient{TRequest, true, TResponse, true},
+        request::Channel{TRequest},
+        response::Channel{TResponse};
+        options...
+    ) where {TRequest <: Any, TResponse <: Any}
 
     req = gRPCRequest(
         client.grpc,
@@ -298,7 +296,7 @@ function grpc_async_request(
     response_task = _spawn(() -> grpc_async_stream_response(req, response), client)
     errormonitor(response_task)
 
-    req
+    return req
 end
 
 
@@ -308,6 +306,6 @@ end
 Raise any exceptions encountered during the streaming request.
 """
 grpc_async_await(
-    client::gRPCServiceClient{TRequest,true,TResponse,false},
+    client::gRPCServiceClient{TRequest, true, TResponse, false},
     request::gRPCRequest,
-) where {TRequest<:Any,TResponse<:Any} = grpc_async_await(request, TResponse)
+) where {TRequest <: Any, TResponse <: Any} = grpc_async_await(request, TResponse)

--- a/src/Unary.jl
+++ b/src/Unary.jl
@@ -30,10 +30,10 @@ end
 ```
 """
 function grpc_async_request(
-    client::gRPCServiceClient{TRequest,false,TResponse,false},
-    request::TRequest;
-    kws...
-) where {TRequest<:Any,TResponse<:Any}
+        client::gRPCServiceClient{TRequest, false, TResponse, false},
+        request::TRequest;
+        kws...
+    ) where {TRequest <: Any, TResponse <: Any}
 
     options = _merge_options(client.options, kws)
 
@@ -53,14 +53,14 @@ function grpc_async_request(
         options
     )
 
-    req
+    return req
 end
 
 
 mutable struct gRPCAsyncChannelResponse{TResponse}
     index::Int64
-    response::Union{Nothing,TResponse}
-    ex::Union{Nothing,Exception}
+    response::Union{Nothing, TResponse}
+    ex::Union{Nothing, Exception}
 end
 
 """
@@ -99,12 +99,12 @@ end
 ```
 """
 function grpc_async_request(
-    client::gRPCServiceClient{TRequest,false,TResponse,false},
-    request::TRequest,
-    channel::Channel{gRPCAsyncChannelResponse{TResponse}},
-    index::Int64;
-    kws...
-) where {TRequest<:Any,TResponse<:Any}
+        client::gRPCServiceClient{TRequest, false, TResponse, false},
+        request::TRequest,
+        channel::Channel{gRPCAsyncChannelResponse{TResponse}},
+        index::Int64;
+        kws...
+    ) where {TRequest <: Any, TResponse <: Any}
 
     options = _merge_options(client.options, kws)
 
@@ -133,7 +133,7 @@ function grpc_async_request(
         end
     end
 
-    nothing
+    return nothing
 end
 
 
@@ -143,9 +143,9 @@ end
 Wait for the request to complete and return the response when it is ready. Throws any exceptions that were encountered during handling of the request.
 """
 grpc_async_await(
-    client::gRPCServiceClient{TRequest,false,TResponse,false},
+    client::gRPCServiceClient{TRequest, false, TResponse, false},
     request::gRPCRequest,
-) where {TRequest<:Any,TResponse<:Any} = grpc_async_await(request, TResponse)
+) where {TRequest <: Any, TResponse <: Any} = grpc_async_await(request, TResponse)
 
 
 """
@@ -173,8 +173,8 @@ response = grpc_sync_request(client, TestRequest(1, zeros(UInt64, 1)))
 ```
 """
 grpc_sync_request(
-    client::gRPCServiceClient{TRequest,false,TResponse,false},
-    request::TRequest; 
+    client::gRPCServiceClient{TRequest, false, TResponse, false},
+    request::TRequest;
     kws...
-) where {TRequest<:Any,TResponse<:Any} =
+) where {TRequest <: Any, TResponse <: Any} =
     grpc_async_await(grpc_async_request(client, request; kws...), TResponse)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,7 +1,7 @@
 function nullstring(x::Vector{UInt8})
     first_zero_idx = findfirst(==(0), x)
     isnothing(first_zero_idx) && return ""
-    String(x[1:(first_zero_idx-1)])
+    return String(x[1:(first_zero_idx - 1)])
 end
 
 # Spawn a task either sticky (pinned to the spawning thread, like `@async`,
@@ -25,5 +25,5 @@ function CROSS_PLATFORM_OS_HANDLE(sock::curl_socket_t)
     else
         sock
     end
-    OS_HANDLE(fd)
+    return OS_HANDLE(fd)
 end

--- a/src/gRPC.jl
+++ b/src/gRPC.jl
@@ -56,21 +56,21 @@ The following keyword arguments may be set:
 - **`token`**: Optional bearer token attached to every request as an `authorization: Bearer <token>` header. 
 - **`metadata`**: A `Dict{String, String}` for adding arbitrary fields to the header. For example, the token field can also added by setting `metadata = Dict("authorization" => "Bearer <token>")` instead of using the `token` keyword. Setting `token` and an `authorization` metadata entry at the same time raises `INVALID_ARGUMENT`, since the two are the same header and sending both would leave which one applies up to the server; the check is case-insensitive. To override a client-level `token` with per-request metadata, pass `token = nothing` alongside it.
 """
-struct gRPCServiceClient{TRequest,SRequest,TResponse,SResponse}
+struct gRPCServiceClient{TRequest, SRequest, TResponse, SResponse}
     grpc::gRPCCURL
     host::String
     port::Int64
     path::String
     options::gRPCConnectionOptions
 
-    function gRPCServiceClient{TRequest,SRequest,TResponse,SResponse}(
-        host,
-        port,
-        path;
-        grpc = grpc_global_handle(),
-        options...
-    ) where {TRequest<:Any,SRequest,TResponse<:Any,SResponse}
-        new(
+    function gRPCServiceClient{TRequest, SRequest, TResponse, SResponse}(
+            host,
+            port,
+            path;
+            grpc = grpc_global_handle(),
+            options...
+        ) where {TRequest <: Any, SRequest, TResponse <: Any, SResponse}
+        return new(
             grpc,
             host,
             port,
@@ -95,7 +95,7 @@ function url(client::gRPCServiceClient)
     # "$protocol://$(client.host):$(client.port)$(client.path)"
     buffer = IOBuffer()
     write(buffer, protocol, "://", client.host, ":", string(client.port), client.path)
-    String(take!(buffer))
+    return String(take!(buffer))
 end
 
 
@@ -108,10 +108,10 @@ _encode_body(buf::IOBuffer, request) = UInt32(encode(ProtoEncoder(buf), request)
 _encode_body(buf::IOBuffer, request::AbstractVector{UInt8}) = UInt32(write(buf, request))
 
 function grpc_encode_request_iobuffer(
-    request,
-    req_buf::IOBuffer;
-    max_send_message_length = 4 * 1024 * 1024,
-)
+        request,
+        req_buf::IOBuffer;
+        max_send_message_length = 4 * 1024 * 1024,
+    )
     start_pos = position(req_buf)
 
     # Write compressed flag and length prefix
@@ -136,19 +136,19 @@ function grpc_encode_request_iobuffer(
     seek(req_buf, start_pos + 1)
     write(req_buf, hton(sz))
 
-    # Seek back to the end 
+    # Seek back to the end
     seek(req_buf, end_pos)
 
-    req_buf
+    return req_buf
 end
 
 
 grpc_encode_request_iobuffer(request; max_send_message_length = 4 * 1024 * 1024) =
     grpc_encode_request_iobuffer(
-        request,
-        IOBuffer();
-        max_send_message_length = max_send_message_length,
-    )
+    request,
+    IOBuffer();
+    max_send_message_length = max_send_message_length,
+)
 
 
 function grpc_async_await(req::gRPCRequest)
@@ -163,7 +163,7 @@ function grpc_async_await(req::gRPCRequest)
 
     req.code == CURLE_OPERATION_TIMEDOUT &&
         throw(gRPCServiceCallException(GRPC_DEADLINE_EXCEEDED, "Deadline exceeded."))
-    req.code != CURLE_OK &&
+    return req.code != CURLE_OK &&
         throw(gRPCServiceCallException(GRPC_INTERNAL, nullstring(req.errbuf)))
 end
 

--- a/src/gRPCClient.jl
+++ b/src/gRPCClient.jl
@@ -53,7 +53,7 @@ const GRPC_UNAVAILABLE = 14
 const GRPC_DATA_LOSS = 15
 const GRPC_UNAUTHENTICATED = 16
 
-const GRPC_CODE_TABLE = Dict{Int64,String}(
+const GRPC_CODE_TABLE = Dict{Int64, String}(
     0 => "OK",
     1 => "CANCELLED",
     2 => "UNKNOWN",
@@ -74,7 +74,7 @@ const GRPC_CODE_TABLE = Dict{Int64,String}(
 )
 
 function Base.showerror(io::IO, e::gRPCServiceCallException)
-    print(
+    return print(
         io,
         "gRPCServiceCallException(grpc_status=$(GRPC_CODE_TABLE[e.grpc_status])($(e.grpc_status)), message=\"$(e.message)\")",
     )
@@ -114,7 +114,7 @@ export gRPCServiceCallException
 
 function __init__()
     grpc_init()
-    grpc_register_service_codegen()
+    return grpc_register_service_codegen()
 end
 
 end

--- a/test/gen/test/test_pb.jl
+++ b/test/gen/test/test_pb.jl
@@ -12,10 +12,10 @@ export TestResponse, TestRequest
 struct TestResponse
     data::Vector{UInt64}
 end
-PB.default_values(::Type{TestResponse}) = (;data = Vector{UInt64}())
-PB.field_numbers(::Type{TestResponse}) = (;data = 1)
+PB.default_values(::Type{TestResponse}) = (; data = Vector{UInt64}())
+PB.field_numbers(::Type{TestResponse}) = (; data = 1)
 
-function PB.decode(d::PB.AbstractProtoDecoder, ::Type{<:TestResponse}, _endpos::Int=0, _group::Bool=false)
+function PB.decode(d::PB.AbstractProtoDecoder, ::Type{<:TestResponse}, _endpos::Int = 0, _group::Bool = false)
     data = PB.BufferedVector{UInt64}()
     while !PB.message_done(d, _endpos, _group)
         field_number, wire_type = PB.decode_tag(d)
@@ -43,10 +43,10 @@ struct TestRequest
     test_response_sz::UInt64
     data::Vector{UInt64}
 end
-PB.default_values(::Type{TestRequest}) = (;test_response_sz = zero(UInt64), data = Vector{UInt64}())
-PB.field_numbers(::Type{TestRequest}) = (;test_response_sz = 1, data = 2)
+PB.default_values(::Type{TestRequest}) = (; test_response_sz = zero(UInt64), data = Vector{UInt64}())
+PB.field_numbers(::Type{TestRequest}) = (; test_response_sz = 1, data = 2)
 
-function PB.decode(d::PB.AbstractProtoDecoder, ::Type{<:TestRequest}, _endpos::Int=0, _group::Bool=false)
+function PB.decode(d::PB.AbstractProtoDecoder, ::Type{<:TestRequest}, _endpos::Int = 0, _group::Bool = false)
     test_response_sz = zero(UInt64)
     data = PB.BufferedVector{UInt64}()
     while !PB.message_done(d, _endpos, _group)
@@ -77,54 +77,54 @@ end
 
 # gRPCClient.jl BEGIN
 TestService_TestRPC_Client(
-	host, port;
-	TRequest=TestRequest,
-	TResponse=TestResponse,
-	grpc=gRPCClient.grpc_global_handle(),
-	options...
+    host, port;
+    TRequest = TestRequest,
+    TResponse = TestResponse,
+    grpc = gRPCClient.grpc_global_handle(),
+    options...
 ) = gRPCClient.gRPCServiceClient{TRequest, false, TResponse, false}(
-	host, port, "/test.TestService/TestRPC";
-	grpc=grpc,
-	options...
+    host, port, "/test.TestService/TestRPC";
+    grpc = grpc,
+    options...
 )
 export TestService_TestRPC_Client
 
 TestService_TestServerStreamRPC_Client(
-	host, port;
-	TRequest=TestRequest,
-	TResponse=TestResponse,
-	grpc=gRPCClient.grpc_global_handle(),
-	options...
+    host, port;
+    TRequest = TestRequest,
+    TResponse = TestResponse,
+    grpc = gRPCClient.grpc_global_handle(),
+    options...
 ) = gRPCClient.gRPCServiceClient{TRequest, false, TResponse, true}(
-	host, port, "/test.TestService/TestServerStreamRPC";
-	grpc=grpc,
-	options...
+    host, port, "/test.TestService/TestServerStreamRPC";
+    grpc = grpc,
+    options...
 )
 export TestService_TestServerStreamRPC_Client
 
 TestService_TestClientStreamRPC_Client(
-	host, port;
-	TRequest=TestRequest,
-	TResponse=TestResponse,
-	grpc=gRPCClient.grpc_global_handle(),
-	options...
+    host, port;
+    TRequest = TestRequest,
+    TResponse = TestResponse,
+    grpc = gRPCClient.grpc_global_handle(),
+    options...
 ) = gRPCClient.gRPCServiceClient{TRequest, true, TResponse, false}(
-	host, port, "/test.TestService/TestClientStreamRPC";
-	grpc=grpc,
-	options...
+    host, port, "/test.TestService/TestClientStreamRPC";
+    grpc = grpc,
+    options...
 )
 export TestService_TestClientStreamRPC_Client
 
 TestService_TestBidirectionalStreamRPC_Client(
-	host, port;
-	TRequest=TestRequest,
-	TResponse=TestResponse,
-	grpc=gRPCClient.grpc_global_handle(),
-	options...
+    host, port;
+    TRequest = TestRequest,
+    TResponse = TestResponse,
+    grpc = gRPCClient.grpc_global_handle(),
+    options...
 ) = gRPCClient.gRPCServiceClient{TRequest, true, TResponse, true}(
-	host, port, "/test.TestService/TestBidirectionalStreamRPC";
-	grpc=grpc,
-	options...
+    host, port, "/test.TestService/TestBidirectionalStreamRPC";
+    grpc = grpc,
+    options...
 )
 export TestService_TestBidirectionalStreamRPC_Client
 # gRPCClient.jl END

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ const _TEST_BEARER_TOKEN = "test-secret-token"
 # This is primarily used for starting the server when running CI.
 # By launching the server asynchronously within julia, we ensure
 # that the server is active while testing, which otherwise would require
-# scheduling a task on windows CI. 
+# scheduling a task on windows CI.
 if haskey(ENV, "JULIA_GRPCCLIENT_TEST_START_SERVER")
     if ENV["JULIA_GRPCCLIENT_TEST_START_SERVER"] == "go"
         pipe = Pipe()
@@ -61,7 +61,7 @@ if haskey(ENV, "JULIA_GRPCCLIENT_TEST_START_SERVER")
 end
 
 function _get_test_host()
-    if "GRPC_TEST_SERVER_HOST" in keys(ENV)
+    return if "GRPC_TEST_SERVER_HOST" in keys(ENV)
         ENV["GRPC_TEST_SERVER_HOST"]
     else
         "localhost"
@@ -69,7 +69,7 @@ function _get_test_host()
 end
 
 function _get_test_port()
-    if "GRPC_TEST_SERVER_PORT" in keys(ENV)
+    return if "GRPC_TEST_SERVER_PORT" in keys(ENV)
         parse(UInt16, ENV["GRPC_TEST_SERVER_PORT"])
     else
         8001
@@ -166,7 +166,7 @@ include("gen/test/test_pb.jl")
         client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
 
         requests = Vector{gRPCRequest}()
-        for i = 1:1000
+        for i in 1:1000
             request = grpc_async_request(client, TestRequest(i, zeros(UInt64, i)))
             push!(requests, request)
         end
@@ -185,7 +185,7 @@ include("gen/test/test_pb.jl")
         client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
 
         requests = Vector{gRPCRequest}()
-        for i = 1:1000
+        for i in 1:1000
             request = grpc_async_request(client, TestRequest(1, zeros(UInt64, 1)))
             push!(requests, request)
         end
@@ -201,9 +201,9 @@ include("gen/test/test_pb.jl")
         client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
 
         requests = Vector{gRPCRequest}()
-        for i = 1:100
+        for i in 1:100
             # 28*224*sizeof(UInt64) == sending batch of 32 224*224 UInt8 image
-            request = grpc_async_request(client, TestRequest(64, zeros(UInt64, 32*28*224)))
+            request = grpc_async_request(client, TestRequest(64, zeros(UInt64, 32 * 28 * 224)))
             push!(requests, request)
         end
 
@@ -216,9 +216,9 @@ include("gen/test/test_pb.jl")
     @testset "Threads.@spawn small request/response" begin
         client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
 
-        responses = [TestResponse(Vector{UInt64}()) for _ = 1:1000]
+        responses = [TestResponse(Vector{UInt64}()) for _ in 1:1000]
 
-        @sync Threads.@threads for i = 1:1000
+        @sync Threads.@threads for i in 1:1000
             response = grpc_sync_request(client, TestRequest(1, zeros(UInt64, 1)))
             responses[i] = response
         end
@@ -232,9 +232,9 @@ include("gen/test/test_pb.jl")
     @testset "Threads.@spawn varying request/response" begin
         client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
 
-        responses = [TestResponse(Vector{UInt64}()) for _ = 1:1000]
+        responses = [TestResponse(Vector{UInt64}()) for _ in 1:1000]
 
-        @sync Threads.@threads for i = 1:1000
+        @sync Threads.@threads for i in 1:1000
             response = grpc_sync_request(client, TestRequest(i, zeros(UInt64, i)))
             responses[i] = response
         end
@@ -251,11 +251,11 @@ include("gen/test/test_pb.jl")
         client = TestService_TestRPC_Client(_TEST_HOST, _TEST_PORT)
 
         channel = Channel{gRPCAsyncChannelResponse{TestResponse}}(1000)
-        for i = 1:1000
+        for i in 1:1000
             grpc_async_request(client, TestRequest(i, zeros(UInt64, 1)), channel, i)
         end
 
-        for i = 1:1000
+        for i in 1:1000
             r = take!(channel)
             !isnothing(r.ex) && throw(r.ex)
             @test r.index == length(r.response.data)
@@ -294,7 +294,7 @@ include("gen/test/test_pb.jl")
             req = grpc_async_request(client, TestRequest(N, zeros(UInt64, 1)), response_c)
 
             # We should get back N messages that end with their length
-            for i = 1:N
+            for i in 1:N
                 response = take_or_diagnose(req, response_c)
                 @test length(response.data) == i
                 @test last(response.data) == i
@@ -314,7 +314,7 @@ include("gen/test/test_pb.jl")
 
             request = grpc_async_request(client, request_c)
 
-            for i = 1:N
+            for i in 1:N
                 put!(request_c, TestRequest(1, zeros(UInt64, 1)))
             end
 
@@ -322,7 +322,7 @@ include("gen/test/test_pb.jl")
             response = grpc_async_await(client, request)
 
             @test length(response.data) == N
-            for i = 1:N
+            for i in 1:N
                 @test response.data[i] == i
             end
         end
@@ -340,11 +340,11 @@ include("gen/test/test_pb.jl")
 
             req = grpc_async_request(client, request_c, response_c)
 
-            for i = 1:N
+            for i in 1:N
                 put!(request_c, TestRequest(i, zeros(UInt64, i)))
             end
 
-            for i = 1:N
+            for i in 1:N
                 response = take_or_diagnose(req, response_c)
                 @test length(response.data) == i
                 @test last(response.data) == i
@@ -377,7 +377,7 @@ include("gen/test/test_pb.jl")
             req = grpc_async_request(client, request_c, response_c)
 
             # Every other response is empty, including the last one
-            sizes = [iseven(i) ? 0 : i for i = 1:N]
+            sizes = [iseven(i) ? 0 : i for i in 1:N]
             for sz in sizes
                 put!(request_c, TestRequest(sz, UInt64[]))
             end
@@ -454,7 +454,7 @@ include("gen/test/test_pb.jl")
             req = grpc_async_request(client, TestRequest(N, zeros(UInt64, 1)), response_c)
 
             # We should get back N small messages
-            for i = 1:N
+            for i in 1:N
                 response = take_or_diagnose(req, response_c)
                 @test length(response.data) >= 1
             end
@@ -474,8 +474,8 @@ include("gen/test/test_pb.jl")
             request = grpc_async_request(client, request_c)
 
             # Send 100 large payloads (similar to unary big test)
-            for i = 1:N
-                put!(request_c, TestRequest(1, zeros(UInt64, 32*28*224)))
+            for i in 1:N
+                put!(request_c, TestRequest(1, zeros(UInt64, 32 * 28 * 224)))
             end
 
             close(request_c)
@@ -611,7 +611,7 @@ include("gen/test/test_pb.jl")
             req = grpc_async_request(client, request_c, response_c)
 
             # Stream is live: request/response round trips work
-            for i = 1:3
+            for i in 1:3
                 put!(request_c, TestRequest(i, zeros(UInt64, i)))
                 r = take!(response_c)
                 @test length(r.data) == i
@@ -637,7 +637,7 @@ include("gen/test/test_pb.jl")
             # Regression for the recycled curl_done_reading Event: the slot freed by
             # the cancelled stream (LIFO freelist, so the next request reuses it) must
             # be clean. Run follow-up streams and unary requests on the same handle.
-            for _ = 1:3
+            for _ in 1:3
                 cs_client = TestService_TestClientStreamRPC_Client(_TEST_HOST, _TEST_PORT)
                 cs_c = Channel{TestRequest}(4)
                 cs_req = grpc_async_request(cs_client, cs_c)
@@ -754,15 +754,17 @@ include("gen/test/test_pb.jl")
     @testset "grpc-timeout header value formatting" begin
         # Per the gRPC HTTP/2 spec, a grpc-timeout value is a positive integer of at most 8 digits
         # followed by a unit char: H (hour), M (minute), S (second), m (ms), u (us), n (ns).
-        _UNIT_NS = Dict('H' => 3_600_000_000_000, 'M' => 60_000_000_000, 'S' => 1_000_000_000,
-                        'm' => 1_000_000, 'u' => 1_000, 'n' => 1)
+        _UNIT_NS = Dict(
+            'H' => 3_600_000_000_000, 'M' => 60_000_000_000, 'S' => 1_000_000_000,
+            'm' => 1_000_000, 'u' => 1_000, 'n' => 1
+        )
         # Decode a header value back to seconds so we can check it never encodes a shorter timeout.
-        decode_s(hv) = parse(Int64, hv[1:end-1]) * _UNIT_NS[hv[end]] / 1e9
+        decode_s(hv) = parse(Int64, hv[1:(end - 1)]) * _UNIT_NS[hv[end]] / 1.0e9
         # Assert the value obeys the spec: 1-8 ASCII digits then a known unit char.
         function is_wellformed(hv)
             length(hv) >= 2 || return false
             haskey(_UNIT_NS, hv[end]) || return false
-            digits = hv[1:end-1]
+            digits = hv[1:(end - 1)]
             1 <= length(digits) <= 8 && all(isdigit, digits)
         end
 
@@ -780,7 +782,7 @@ include("gen/test/test_pb.jl")
             @test grpc_timeout_header_val(0.0005) == "500u"
             # Whole nanoseconds render as n.
             @test grpc_timeout_header_val(0.0000001) == "100n"
-            @test grpc_timeout_header_val(1e-9) == "1n"
+            @test grpc_timeout_header_val(1.0e-9) == "1n"
         end
 
         @testset "coarsest exact unit is preferred" begin
@@ -810,9 +812,9 @@ include("gen/test/test_pb.jl")
             @test grpc_timeout_header_val(0) == "0S"     # zero is valid: immediate deadline
             # A strictly positive timeout must never round DOWN to "0S" (already-expired). Values
             # below half a nanosecond floor at one nanosecond instead of collapsing to zero.
-            @test grpc_timeout_header_val(1e-10) == "1n"
-            @test grpc_timeout_header_val(4e-10) == "1n"
-            @test grpc_timeout_header_val(1e-12) == "1n"
+            @test grpc_timeout_header_val(1.0e-10) == "1n"
+            @test grpc_timeout_header_val(4.0e-10) == "1n"
+            @test grpc_timeout_header_val(1.0e-12) == "1n"
         end
 
         @testset "narrow and exotic Real types" begin
@@ -839,22 +841,24 @@ include("gen/test/test_pb.jl")
                 e isa gRPCServiceCallException && e.grpc_status == gRPCClient.GRPC_INVALID_ARGUMENT
             end
             @test invalid_arg(() -> grpc_timeout_header_val(-1))          # negative
-            @test invalid_arg(() -> grpc_timeout_header_val(-1e-9))       # negative, sub-nanosecond
+            @test invalid_arg(() -> grpc_timeout_header_val(-1.0e-9))       # negative, sub-nanosecond
             @test invalid_arg(() -> grpc_timeout_header_val(Inf))         # non-finite
             @test invalid_arg(() -> grpc_timeout_header_val(NaN))         # non-finite
-            @test invalid_arg(() -> grpc_timeout_header_val(1e12))        # beyond Int64 ns (~292y)
+            @test invalid_arg(() -> grpc_timeout_header_val(1.0e12))        # beyond Int64 ns (~292y)
         end
 
         @testset "invariants over a wide sweep" begin
             # For every timeout, the header must be well-formed (<=8 digits + valid unit) and must
             # never encode a SHORTER timeout than requested (rounding is always up).
-            vals = Float64[0, 1e-9, 5e-9, 1e-7, 0.0005, 0.05, 0.099999999, 0.1, 0.5, 1, 2.5,
-                           9.9999999, 10.0000001, 29.999999046, 60, 90.0001, 123.4567, 3600,
-                           99_999.9994, 1e6 + 0.5, 99_999_999]
+            vals = Float64[
+                0, 1.0e-9, 5.0e-9, 1.0e-7, 0.0005, 0.05, 0.099999999, 0.1, 0.5, 1, 2.5,
+                9.9999999, 10.0000001, 29.999999046, 60, 90.0001, 123.4567, 3600,
+                99_999.9994, 1.0e6 + 0.5, 99_999_999,
+            ]
             for t in vals
                 hv = grpc_timeout_header_val(t)
                 @test is_wellformed(hv)
-                @test decode_s(hv) >= t - 1e-9
+                @test decode_s(hv) >= t - 1.0e-9
             end
         end
     end
@@ -879,7 +883,7 @@ include("gen/test/test_pb.jl")
             TestRequest(1024, zeros(UInt64, 1)),
         )
     end
-    
+
     function client_authorizes(client; kws...)
         # A client configured with the correct bearer token sends
         # `authorization: Bearer <token>`, which the test server validates.
@@ -943,7 +947,7 @@ include("gen/test/test_pb.jl")
         )
         @test client_fails_authorization(bad_client)
     end
-    
+
     @testset "_merge_options" begin
         # Most options should be plainly overridden
         options = gRPCClient.gRPCConnectionOptions()
@@ -963,11 +967,11 @@ include("gen/test/test_pb.jl")
 
         # set metadata = nothing in gRPCConnectionOptions
         opts = gRPCClient.gRPCConnectionOptions(metadata = nothing)
-        gRPCClient._merge_options(opts, Dict{Symbol,Any}(:metadata => Dict("x" => "1")))
+        gRPCClient._merge_options(opts, Dict{Symbol, Any}(:metadata => Dict("x" => "1")))
 
         # Check rejection of invalid arguments
         opts = gRPCClient.gRPCConnectionOptions(metadata = nothing)
-        @test_throws ArgumentError gRPCClient._merge_options(opts, Dict{Symbol,Any}(:not_a_key => Dict("x" => "1")))
+        @test_throws ArgumentError gRPCClient._merge_options(opts, Dict{Symbol, Any}(:not_a_key => Dict("x" => "1")))
     end
 
     @testset "token and authorization metadata conflict" begin
@@ -981,7 +985,7 @@ include("gen/test/test_pb.jl")
                 return false
             catch ex
                 return isa(ex, gRPCServiceCallException) &&
-                       ex.grpc_status == GRPC_INVALID_ARGUMENT
+                    ex.grpc_status == GRPC_INVALID_ARGUMENT
             end
         end
 
@@ -1059,7 +1063,7 @@ include("gen/test/test_pb.jl")
         )
         # Bad token provided to grpc_sync_request should override
         @test client_fails_authorization(good_client; token = "bad token")
- 
+
         # Client has bad token
         bad_client = TestService_TestRPC_Client(
             _TEST_HOST,
@@ -1081,7 +1085,7 @@ include("gen/test/test_pb.jl")
         N = 100
         tasks = Vector{Task}(undef, N)
 
-        for i = 1:N
+        for i in 1:N
             tasks[i] = @spawn begin
                 try
                     # Make requests with varying sizes
@@ -1148,14 +1152,14 @@ include("gen/test/test_pb.jl")
         t0 = time()
         tasks = [
             @spawn begin
-                try
-                    request = grpc_async_request(client, TestRequest(1, zeros(UInt64, 1)))
-                    grpc_async_await(client, request)
-                    nothing
+                    try
+                        request = grpc_async_request(client, TestRequest(1, zeros(UInt64, 1)))
+                        grpc_async_await(client, request)
+                        nothing
                 catch ex
-                    ex
+                        ex
                 end
-            end for _ = 1:N
+                end for _ in 1:N
         ]
         results = fetch.(tasks)
         elapsed = time() - t0
@@ -1163,8 +1167,8 @@ include("gen/test/test_pb.jl")
         # Every request resolved (no wedge) with DEADLINE_EXCEEDED at ~deadline per batch
         @test all(
             ex ->
-                isa(ex, gRPCServiceCallException) &&
-                    ex.grpc_status == GRPC_DEADLINE_EXCEEDED,
+            isa(ex, gRPCServiceCallException) &&
+                ex.grpc_status == GRPC_DEADLINE_EXCEEDED,
             results,
         )
         # Two semaphore batches, each bounded by deadline + watchdog grace; generous margin

--- a/utils/gRPCClientUtils.jl/src/Benchmark.jl
+++ b/utils/gRPCClientUtils.jl/src/Benchmark.jl
@@ -10,16 +10,16 @@ function perform_benchmark(f)
     N = f()
 
     b = @benchmark $f($N)
-    timing = sum(b.times) / 1e9
-    timings_us = b.times ./ 1e3
+    timing = sum(b.times) / 1.0e9
+    timings_us = b.times ./ 1.0e3
     N_sample = length(b.times) * N
-    mem = round(b.memory / (1024*1024), digits = 2)
+    mem = round(b.memory / (1024 * 1024), digits = 2)
 
     return [
         f,
-        1000*mem / N, # Avg Memory
+        1000 * mem / N, # Avg Memory
         round(b.allocs / N, digits = 1), # Avg Allocs
-        round(Int, N_sample/timing), # Throughput
+        round(Int, N_sample / timing), # Throughput
         round(Int, mean(timings_us) / N), # Avg duration
         round(std(timings_us) / N, digits = 2),
         round(Int, minimum(timings_us) / N),
@@ -51,7 +51,7 @@ function benchmark_table()
 
     all_results = [perform_benchmark(f) for f in ProgressBar(all_benchmarks)]
 
-    pretty_table(
+    return pretty_table(
         permutedims(reduce(hcat, all_results));
         column_labels = column_labels,
         style = TextTableStyle(first_line_column_label = crayon"yellow bold"),

--- a/utils/gRPCClientUtils.jl/src/Profile.jl
+++ b/utils/gRPCClientUtils.jl/src/Profile.jl
@@ -3,8 +3,8 @@ function profile_memory_fn(f::Function)
     _ = f()
 
     Profile.Allocs.clear()
-    Profile.Allocs.@profile sample_rate=0.1 f()
-    PProf.Allocs.pprof()
+    Profile.Allocs.@profile sample_rate = 0.1 f()
+    return PProf.Allocs.pprof()
 end
 
 profile_memory_workload_smol() = profile_memory_fn(workload_smol)

--- a/utils/gRPCClientUtils.jl/src/Stress.jl
+++ b/utils/gRPCClientUtils.jl/src/Stress.jl
@@ -2,6 +2,7 @@ function stress_workload(f::Function)
     while true
         f()
     end
+    return
 end
 
 stress_workload_smol() = stress_workload(workload_smol)

--- a/utils/gRPCClientUtils.jl/src/Workloads.jl
+++ b/utils/gRPCClientUtils.jl/src/Workloads.jl
@@ -6,11 +6,11 @@ function workload_32_224_224_uint8(n = 100)
 
     reqs = Vector{gRPCRequest}()
 
-    send_sz = 32*224*224÷sizeof(UInt64)
+    send_sz = 32 * 224 * 224 ÷ sizeof(UInt64)
     # Pre-allocate this so we are measuring gRPC client performance without external allocations
     test_buf = zeros(UInt64, send_sz)
 
-    for i = 1:n
+    for i in 1:n
         req = grpc_async_request(client, TestRequest(32, test_buf))
         push!(reqs, req)
     end
@@ -18,7 +18,7 @@ function workload_32_224_224_uint8(n = 100)
         grpc_async_await(req)
     end
 
-    n
+    return n
 end
 
 function workload_smol(n = 1_000)
@@ -26,7 +26,7 @@ function workload_smol(n = 1_000)
 
     # Since requests are lightweight, use async / await pattern to avoid creating an extra task per request
     reqs = Vector{gRPCRequest}()
-    for i = 1:n
+    for i in 1:n
         req = grpc_async_request(client, TestRequest(1, zeros(UInt64, 1)))
         push!(reqs, req)
     end
@@ -35,7 +35,7 @@ function workload_smol(n = 1_000)
         grpc_async_await(req)
     end
 
-    n
+    return n
 end
 
 function workload_streaming_request(n = 1_000)
@@ -45,7 +45,7 @@ function workload_streaming_request(n = 1_000)
     @sync begin
         req = grpc_async_request(client, requests_c)
 
-        for i = 1:n
+        for i in 1:n
             put!(requests_c, TestRequest(1, zeros(UInt64, 1)))
         end
 
@@ -54,7 +54,7 @@ function workload_streaming_request(n = 1_000)
         response = grpc_async_await(req)
     end
 
-    n
+    return n
 end
 
 function workload_streaming_response(n = 1_000)
@@ -63,12 +63,12 @@ function workload_streaming_response(n = 1_000)
 
     req = grpc_async_request(client, TestRequest(n, zeros(UInt64, 1)), response_c)
 
-    for i = 1:n
+    for i in 1:n
         take!(response_c)
     end
     close(response_c)
 
-    n
+    return n
 end
 
 
@@ -81,7 +81,7 @@ function workload_streaming_bidirectional(n = 1_000)
         req = grpc_async_request(client, requests_c, response_c)
 
         task_request = Threads.@spawn begin
-            for i = 1:n
+            for i in 1:n
                 put!(requests_c, TestRequest(1, zeros(UInt64, 1)))
             end
             close(requests_c)
@@ -89,7 +89,7 @@ function workload_streaming_bidirectional(n = 1_000)
         errormonitor(task_request)
 
         task_response = Threads.@spawn begin
-            for i = 1:n
+            for i in 1:n
                 take!(response_c)
             end
             close(response_c)
@@ -99,5 +99,5 @@ function workload_streaming_bidirectional(n = 1_000)
         nothing
     end
 
-    n
+    return n
 end


### PR DESCRIPTION
- Add a CONTRIBUTORS.md with instructions on how to run Runic.jl for contributions.
- Run `runic inplace .` on the repo
- Add Runic format check as part of CI