### PR TITLE
Update compat bounds / bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "gRPCClient"
 uuid = "aaca4a50-36af-4a1d-b878-4c443f2061ad"
-version = "1.1.0-rc2"
+version = "1.1.0"
 authors = ["Carroll Vance <cs.vance@icloud.com>"]
 
 [deps]
@@ -11,9 +11,9 @@ ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 
 [compat]
 FileWatching = "^1.10"
-LibCURL = "~0.6.4, 1"
+LibCURL = "0.6.4 - 1"
 PrecompileTools = "^1.2"
-ProtoBuf = "~1.2.1, ~1.3"
+ProtoBuf = "~1.2.1, 1.3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
- For v1.1.0 release
- More flexible compat bounds for ProtoBuf and LibCURL